### PR TITLE
Add workspace anchors for capability deep links

### DIFF
--- a/hosting/app/capabilities.ts
+++ b/hosting/app/capabilities.ts
@@ -1,0 +1,178 @@
+export interface WorkspaceConfigEntry {
+  tab: string;
+  title: string;
+  description: string;
+  defaultAnchor?: string;
+}
+
+const WORKSPACE_CONFIG = {
+  dashboard: {
+    tab: 'dashboard',
+    title: 'Engagement Dashboard',
+    description: 'At-a-glance POV outcomes, activity feeds, and blueprint automation shortcuts.',
+    defaultAnchor: 'dashboard-blueprints'
+  },
+  'domain-consultant': {
+    tab: 'dashboard',
+    title: 'Domain Consultant Workspace',
+    description: 'Shortcut alias for the engagement dashboard workspace experience.',
+    defaultAnchor: 'dashboard-blueprints'
+  },
+  pov: {
+    tab: 'pov',
+    title: 'POV Planning Hub',
+    description: 'Lifecycle orchestration, scenario planning, and AI-assisted milestone tracking.',
+    defaultAnchor: 'pov-planning-hub'
+  },
+  trr: {
+    tab: 'trr',
+    title: 'TRR Notes Workbench',
+    description: 'Central location for requirement notes, evidence management, and approvals.',
+    defaultAnchor: 'notes-workbench'
+  },
+  analytics: {
+    tab: 'data',
+    title: 'Data Analytics Panel',
+    description: 'Customer analytics, export builders, and engagement dashboards.',
+    defaultAnchor: 'data-analytics-panel'
+  },
+  ai: {
+    tab: 'ai',
+    title: 'AI Advisor Console',
+    description: 'Guided playbooks, contextual insights, and executive-ready narratives.',
+    defaultAnchor: 'ai-advisor-console'
+  },
+  platform: {
+    tab: 'xsiam',
+    title: 'Platform Health Monitor',
+    description: 'Visibility into XSIAM environment health, alerts, and troubleshooting flows.',
+    defaultAnchor: 'platform-health-monitor'
+  },
+  creator: {
+    tab: 'creator',
+    title: 'Demo Blueprint Studio',
+    description: 'Rapid demo authoring, workbook templates, and solution storytelling kits.',
+    defaultAnchor: 'demo-blueprint-studio'
+  },
+  content: {
+    tab: 'scenarios',
+    title: 'Content Intelligence Library',
+    description: 'Searchable content collections, battlecards, and POV-ready scenario bundles.',
+    defaultAnchor: 'content-intelligence-library'
+  },
+  management: {
+    tab: 'admin',
+    title: 'Management Control Center',
+    description: 'Team oversight, performance analytics, and feature rollout coordination.',
+    defaultAnchor: 'management-control-center'
+  }
+} satisfies Record<string, WorkspaceConfigEntry>;
+
+export type WorkspaceSlug = keyof typeof WORKSPACE_CONFIG;
+
+export const workspaceConfig: Record<WorkspaceSlug, WorkspaceConfigEntry> = WORKSPACE_CONFIG;
+
+export const workspaceSlugs: WorkspaceSlug[] = Object.keys(WORKSPACE_CONFIG) as WorkspaceSlug[];
+
+export interface WorkspaceCapabilityLink {
+  id: string;
+  title: string;
+  description: string;
+  href: string;
+  anchor: string;
+  workspace: WorkspaceSlug;
+  type: 'capability' | 'resource' | 'action';
+}
+
+export const workspaceCapabilityLinks: WorkspaceCapabilityLink[] = [
+  {
+    id: 'blueprint-automation',
+    title: 'Blueprint Automation',
+    description: 'Generate executive-ready transformation blueprints directly from the dashboard.',
+    href: '/workspaces/dashboard#dashboard-blueprints',
+    anchor: 'dashboard-blueprints',
+    workspace: 'dashboard',
+    type: 'capability'
+  },
+  {
+    id: 'pov-planning',
+    title: 'POV Planning Hub',
+    description: 'Coordinate scenarios, timelines, and stakeholder objectives inside the POV workspace.',
+    href: '/workspaces/pov#pov-planning-hub',
+    anchor: 'pov-planning-hub',
+    workspace: 'pov',
+    type: 'capability'
+  },
+  {
+    id: 'trr-notes',
+    title: 'TRR Notes Workbench',
+    description: 'Capture validation notes, link SDWs, and manage approvals in one workspace.',
+    href: '/workspaces/trr#notes-workbench',
+    anchor: 'notes-workbench',
+    workspace: 'trr',
+    type: 'capability'
+  },
+  {
+    id: 'analytics-insights',
+    title: 'Data Analytics Panel',
+    description: 'Build exports, review job history, and visualize engagement metrics.',
+    href: '/workspaces/analytics#data-analytics-panel',
+    anchor: 'data-analytics-panel',
+    workspace: 'analytics',
+    type: 'capability'
+  },
+  {
+    id: 'ai-advisor',
+    title: 'AI Advisor Console',
+    description: 'Tap into contextual insights, recommendations, and reusable response templates.',
+    href: '/workspaces/ai#ai-advisor-console',
+    anchor: 'ai-advisor-console',
+    workspace: 'ai',
+    type: 'capability'
+  },
+  {
+    id: 'platform-monitoring',
+    title: 'Platform Health Monitor',
+    description: 'Track XSIAM system health, live alerts, and guided troubleshooting steps.',
+    href: '/workspaces/platform#platform-health-monitor',
+    anchor: 'platform-health-monitor',
+    workspace: 'platform',
+    type: 'capability'
+  },
+  {
+    id: 'demo-studio',
+    title: 'Demo Blueprint Studio',
+    description: 'Author custom demos, content templates, and solution walkthroughs.',
+    href: '/workspaces/creator#demo-blueprint-studio',
+    anchor: 'demo-blueprint-studio',
+    workspace: 'creator',
+    type: 'capability'
+  },
+  {
+    id: 'content-library',
+    title: 'Content Intelligence Library',
+    description: 'Browse curated battlecards and ready-to-deploy scenarios for customer engagements.',
+    href: '/workspaces/content#content-intelligence-library',
+    anchor: 'content-intelligence-library',
+    workspace: 'content',
+    type: 'resource'
+  },
+  {
+    id: 'management-center',
+    title: 'Management Control Center',
+    description: 'Oversee consultant activity, feature adoption, and team-level performance.',
+    href: '/workspaces/management#management-control-center',
+    anchor: 'management-control-center',
+    workspace: 'management',
+    type: 'capability'
+  }
+];
+
+export const resolveWorkspaceSlug = (slug: string): WorkspaceSlug => {
+  if ((slug as WorkspaceSlug) in WORKSPACE_CONFIG) {
+    return slug as WorkspaceSlug;
+  }
+
+  return 'dashboard';
+};
+

--- a/hosting/app/workspaces/[workspace]/WorkspacePageClient.tsx
+++ b/hosting/app/workspaces/[workspace]/WorkspacePageClient.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { useAuth } from '../../../contexts/AuthContext';
+import { Loading } from '../../../components/ui';
+import { workspaceConfig, WorkspaceSlug } from '../../capabilities';
+
+const CortexGUIInterface = dynamic(() => import('../../../components/CortexGUIInterface'), {
+  ssr: false,
+  loading: () => <Loading size="lg" text="Loading workspace experience..." fullscreen />
+});
+
+interface WorkspacePageClientProps {
+  workspaceKey: WorkspaceSlug;
+}
+
+
+export default function WorkspacePageClient({ workspaceKey }: WorkspacePageClientProps) {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const config = workspaceConfig[workspaceKey];
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.replace('/');
+    }
+  }, [loading, user, router]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (config?.defaultAnchor && !window.location.hash) {
+      window.location.hash = config.defaultAnchor;
+    }
+  }, [config?.defaultAnchor, workspaceKey]);
+
+  if (loading) {
+    return <Loading size="lg" text="Verifying workspace access..." fullscreen />;
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-cortex-bg-primary">
+      <div className="border-b border-cortex-border-secondary/40 bg-cortex-bg-secondary/30 backdrop-blur-sm">
+        <div className="max-w-6xl mx-auto px-6 py-6 space-y-2">
+          <p className="text-xs uppercase tracking-widest text-cortex-text-muted">Workspace</p>
+          <h1 className="text-2xl font-semibold text-cortex-text-primary">{config.title}</h1>
+          <p className="text-sm text-cortex-text-secondary max-w-3xl">{config.description}</p>
+        </div>
+      </div>
+
+      <CortexGUIInterface initialTab={config.tab} />
+    </div>
+  );
+}

--- a/hosting/app/workspaces/[workspace]/page.tsx
+++ b/hosting/app/workspaces/[workspace]/page.tsx
@@ -1,0 +1,21 @@
+import WorkspacePageClient from './WorkspacePageClient';
+import { resolveWorkspaceSlug, workspaceSlugs } from '../../capabilities';
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return workspaceSlugs.map((workspace) => ({ workspace }));
+}
+
+
+interface WorkspacePageProps {
+  params: {
+    workspace: string;
+  };
+}
+
+export default function WorkspacePage({ params }: WorkspacePageProps) {
+  const workspaceKey = resolveWorkspaceSlug(params.workspace);
+
+  return <WorkspacePageClient workspaceKey={workspaceKey} />;
+}

--- a/hosting/components/BigQueryExplorer.tsx
+++ b/hosting/components/BigQueryExplorer.tsx
@@ -497,11 +497,20 @@ ORDER BY success_rate DESC, times_used DESC`,
   );
 
   return (
-    <div className="p-8 space-y-8">
+    <section
+      id="data-analytics-panel"
+      aria-labelledby="data-analytics-panel-heading"
+      className="p-8 space-y-8 scroll-mt-28"
+    >
       <div className="glass-card p-8">
         <div className="flex items-center justify-between mb-8">
           <div>
-            <h1 className="text-3xl font-bold text-cortex-text-primary mb-2">BigQuery Data Explorer</h1>
+            <h1
+              id="data-analytics-panel-heading"
+              className="text-3xl font-bold text-cortex-text-primary mb-2"
+            >
+              BigQuery Data Explorer
+            </h1>
             <p className="text-cortex-text-muted">Comprehensive data export and analytics platform for DC workflows</p>
           </div>
         </div>
@@ -548,6 +557,6 @@ ORDER BY success_rate DESC, times_used DESC`,
           {activeTab === 'analytics' && <AnalyticsTab />}
         </div>
       </div>
-    </div>
+    </section>
   );
 };

--- a/hosting/components/CortexGUIInterface.tsx
+++ b/hosting/components/CortexGUIInterface.tsx
@@ -2,7 +2,7 @@
 // legacy-orange: replaced by green per Cortex rebrand (2025-10-08)
 
 
-import React, { useState, useEffect, useCallback, useMemo, lazy, Suspense } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, lazy, Suspense, useRef } from 'react';
 import { useActivityTracking } from '../hooks/useActivityTracking';
 import { useCommandExecutor } from '../hooks/useCommandExecutor';
 import { userManagementService } from '../lib/user-management';
@@ -38,6 +38,7 @@ interface GUITab {
   description: string;
 }
 
+
 interface QuickAction {
   name: string;
   icon: string;
@@ -45,6 +46,19 @@ interface QuickAction {
   onClick: () => void;
   className: string;
 }
+
+const DEFAULT_TAB_ID = 'dashboard';
+const ANCHOR_TAB_MAP: Record<string, string> = {
+  'dashboard-blueprints': 'dashboard',
+  'pov-planning-hub': 'pov',
+  'notes-workbench': 'trr',
+  'platform-health-monitor': 'xsiam',
+  'ai-advisor-console': 'ai',
+  'data-analytics-panel': 'data',
+  'demo-blueprint-studio': 'creator',
+  'content-intelligence-library': 'scenarios',
+  'management-control-center': 'admin'
+};
 
 const POVDashboard = React.memo(({ terminalExpanded, setTerminalExpanded }: { terminalExpanded: boolean; setTerminalExpanded: (expanded: boolean) => void }) => {
   const { run: executeCommand, isRunning } = useCommandExecutor();
@@ -334,106 +348,118 @@ const POVDashboard = React.memo(({ terminalExpanded, setTerminalExpanded }: { te
           </div>
         
         {/* Quick Actions Card */}
-        <div className="glass-card p-6">
-            <div className="flex items-center justify-between mb-6">
-              <h3 className="text-xl font-semibold text-cortex-text-primary flex items-center">
+        <section
+          id="dashboard-blueprints"
+          aria-labelledby="dashboard-blueprints-heading"
+          className="glass-card p-6 scroll-mt-28"
+        >
+          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between mb-6">
+            <div>
+              <h3
+                id="dashboard-blueprints-heading"
+                className="text-xl font-semibold text-cortex-text-primary flex items-center"
+              >
                 <span className="text-cortex-accent mr-2">⚡</span>
                 Quick Actions
               </h3>
-              <div className="text-xs bg-cortex-accent/10 text-cortex-accent px-3 py-1 rounded-full border border-cortex-accent/20">
-                7 Available
-              </div>
+              <p className="text-sm text-cortex-text-muted">
+                Launch blueprint automation, exports, and workspace shortcuts without leaving the dashboard.
+              </p>
             </div>
-            
-            <div className="grid grid-cols-2 gap-3 mb-6">
-              {quickActions.map((action, idx) => (
-                <button
-                  key={idx}
-                  onClick={action.onClick}
-                  className="btn-modern button-hover-lift cortex-card p-4 text-center"
-                  title={action.description}
-                >
-                  <div className="text-2xl mb-2 group-hover:scale-110 transition-transform">{action.icon}</div>
-                  <div className="text-xs font-medium text-cortex-text-secondary group-hover:text-cortex-text-primary transition-colors">
-                    {action.name}
-                  </div>
-                </button>
-              ))}
-            </div>
-            
-            {/* Advanced Actions */}
-            <div className="border-t border-cortex-border-muted/20 pt-4">
-              <h4 className="text-sm font-medium text-cortex-text-secondary mb-3">Advanced Actions</h4>
-              <div className="space-y-2">
-                <button 
-                  onClick={() => {
-                    const event = new CustomEvent('navigate-to-tab', { detail: { tabId: 'xsiam', action: 'sync-platform' } });
-                    window.dispatchEvent(event);
-                  }}
-                  className="w-full text-left p-3 rounded-lg hover:bg-cortex-bg-secondary/30 transition-colors text-sm text-cortex-text-muted hover:text-cortex-text-primary flex items-center space-x-3 cortex-interactive"
-                >
-                  <span>🔄</span>
-                  <span>Sync demo environment</span>
-                </button>
-                <button 
-                  onClick={() => {
-                    const event = new CustomEvent('navigate-to-tab', { detail: { tabId: 'data', action: 'export-dashboard' } });
-                    window.dispatchEvent(event);
-                  }}
-                  className="w-full text-left p-3 rounded-lg hover:bg-cortex-bg-secondary/30 transition-colors text-sm text-cortex-text-muted hover:text-cortex-text-primary flex items-center space-x-3 cortex-interactive"
-                >
-                  <span>📋</span>
-                  <span>Export current dashboard</span>
-                </button>
-                <button 
-                  onClick={() => {
-                    const event = new CustomEvent('navigate-to-tab', { detail: { tabId: 'data', action: 'engagement-metrics' } });
-                    window.dispatchEvent(event);
-                  }}
-                  className="w-full text-left p-3 rounded-lg hover:bg-cortex-bg-secondary/30 transition-colors text-sm text-cortex-text-muted hover:text-cortex-text-primary flex items-center space-x-3 cortex-interactive"
-                >
-                  <span>📊</span>
-                  <span>View engagement metrics</span>
-                </button>
-                <button 
-                  onClick={() => {
-                    const event = new CustomEvent('navigate-to-tab', { detail: { tabId: 'trr', action: 'create-sdw' } });
-                    window.dispatchEvent(event);
-                  }}
-                  className="w-full text-left p-3 rounded-lg hover:bg-cortex-warning/10 transition-colors text-sm text-cortex-warning hover:text-cortex-warning border border-cortex-warning/20 hover:border-cortex-warning/40 mt-3 cortex-interactive"
-                >
-                  <div className="flex items-center space-x-3">
-                    <span>📝</span>
-                    <span>Create Solution Design Workbook</span>
-                  </div>
-                </button>
-                <button 
-                  onClick={async () => {
-                    setTerminalExpanded(!terminalExpanded);
-                    if (!terminalExpanded) {
-                      await executeCommand('whoami', {
-                        openTerminal: true,
-                        focus: true,
-                        trackActivity: {
-                          event: 'terminal-sidebar-open',
-                          source: 'dashboard-advanced-actions',
-                          payload: { action: 'toggle-terminal', expanded: !terminalExpanded }
-                        }
-                      });
-                    }
-                  }}
-                  className="w-full text-left p-3 rounded-lg hover:bg-cortex-success/10 transition-colors text-sm text-cortex-success hover:text-cortex-success border border-cortex-success/20 hover:border-cortex-success/40 cortex-interactive"
-                >
-                  <div className="flex items-center space-x-3">
-                    <span>⌨️</span>
-                    <span>{terminalExpanded ? 'Hide Terminal Sidebar' : 'Show Terminal Sidebar'}</span>
-                  </div>
-                </button>
-              </div>
+            <div className="text-xs bg-cortex-accent/10 text-cortex-accent px-3 py-1 rounded-full border border-cortex-accent/20">
+              7 Available
             </div>
           </div>
-        </div>
+
+          <div className="grid grid-cols-2 gap-3 mb-6">
+            {quickActions.map((action, idx) => (
+              <button
+                key={idx}
+                onClick={action.onClick}
+                className="btn-modern button-hover-lift cortex-card p-4 text-center"
+                title={action.description}
+              >
+                <div className="text-2xl mb-2 group-hover:scale-110 transition-transform">{action.icon}</div>
+                <div className="text-xs font-medium text-cortex-text-secondary group-hover:text-cortex-text-primary transition-colors">
+                  {action.name}
+                </div>
+              </button>
+            ))}
+          </div>
+
+          {/* Advanced Actions */}
+          <div className="border-t border-cortex-border-muted/20 pt-4">
+            <h4 className="text-sm font-medium text-cortex-text-secondary mb-3">Advanced Actions</h4>
+            <div className="space-y-2">
+              <button
+                onClick={() => {
+                  const event = new CustomEvent('navigate-to-tab', { detail: { tabId: 'xsiam', action: 'sync-platform' } });
+                  window.dispatchEvent(event);
+                }}
+                className="w-full text-left p-3 rounded-lg hover:bg-cortex-bg-secondary/30 transition-colors text-sm text-cortex-text-muted hover:text-cortex-text-primary flex items-center space-x-3 cortex-interactive"
+              >
+                <span>🔄</span>
+                <span>Sync demo environment</span>
+              </button>
+              <button
+                onClick={() => {
+                  const event = new CustomEvent('navigate-to-tab', { detail: { tabId: 'data', action: 'export-dashboard' } });
+                  window.dispatchEvent(event);
+                }}
+                className="w-full text-left p-3 rounded-lg hover:bg-cortex-bg-secondary/30 transition-colors text-sm text-cortex-text-muted hover:text-cortex-text-primary flex items-center space-x-3 cortex-interactive"
+              >
+                <span>📋</span>
+                <span>Export current dashboard</span>
+              </button>
+              <button
+                onClick={() => {
+                  const event = new CustomEvent('navigate-to-tab', { detail: { tabId: 'data', action: 'engagement-metrics' } });
+                  window.dispatchEvent(event);
+                }}
+                className="w-full text-left p-3 rounded-lg hover:bg-cortex-bg-secondary/30 transition-colors text-sm text-cortex-text-muted hover:text-cortex-text-primary flex items-center space-x-3 cortex-interactive"
+              >
+                <span>📊</span>
+                <span>View engagement metrics</span>
+              </button>
+              <button
+                onClick={() => {
+                  const event = new CustomEvent('navigate-to-tab', { detail: { tabId: 'trr', action: 'create-sdw' } });
+                  window.dispatchEvent(event);
+                }}
+                className="w-full text-left p-3 rounded-lg hover:bg-cortex-warning/10 transition-colors text-sm text-cortex-warning hover:text-cortex-warning border border-cortex-warning/20 hover:border-cortex-warning/40 mt-3 cortex-interactive"
+              >
+                <div className="flex items-center space-x-3">
+                  <span>📝</span>
+                  <span>Create Solution Design Workbook</span>
+                </div>
+              </button>
+              <button
+                onClick={async () => {
+                  setTerminalExpanded(!terminalExpanded);
+                  if (!terminalExpanded) {
+                    await executeCommand('whoami', {
+                      openTerminal: true,
+                      focus: true,
+                      trackActivity: {
+                        event: 'terminal-sidebar-open',
+                        source: 'dashboard-advanced-actions',
+                        payload: { action: 'toggle-terminal', expanded: !terminalExpanded }
+                      }
+                    });
+                  }
+                }}
+                className="w-full text-left p-3 rounded-lg hover:bg-cortex-success/10 transition-colors text-sm text-cortex-success hover:text-cortex-success border border-cortex-success/20 hover:border-cortex-success/40 cortex-interactive"
+              >
+                <div className="flex items-center space-x-3">
+                  <span>⌨️</span>
+                  <span>{terminalExpanded ? 'Hide Terminal Sidebar' : 'Show Terminal Sidebar'}</span>
+                </div>
+              </button>
+            </div>
+          </div>
+        </section>
       </div>
+    </div>
   );
 });
 POVDashboard.displayName = 'POVDashboard';
@@ -506,8 +532,14 @@ const guiTabs: GUITab[] = [
   }
 ];
 
-export default function CortexGUIInterface() {
-  const [activeTab, setActiveTab] = useState('dashboard');
+interface CortexGUIInterfaceProps {
+  initialTab?: string;
+}
+
+export default function CortexGUIInterface({ initialTab }: CortexGUIInterfaceProps) {
+  const [activeTab, setActiveTab] = useState(() =>
+    initialTab && guiTabs.some(tab => tab.id === initialTab) ? initialTab : DEFAULT_TAB_ID
+  );
   const [currentUser, setCurrentUser] = useState(null);
   const [isManagementMode, setIsManagementMode] = useState(false);
   const [userPermissions, setUserPermissions] = useState({});
@@ -516,7 +548,7 @@ export default function CortexGUIInterface() {
   
   const { trackFeatureUsage, trackPageView } = useActivityTracking();
   const { run: executeCommand, isRunning } = useCommandExecutor();
-  
+
   useEffect(() => {
     // Initialize user context and permissions
     const users = userManagementService.getAllUsers();
@@ -560,28 +592,73 @@ export default function CortexGUIInterface() {
     return () => clearInterval(interval);
   }, []);
   
-  const handleTabChange = useCallback((tabId: string, action?: string, metadata?: any) => {
-    const previousTab = activeTab;
-    setActiveTab(tabId);
-    
-    // Track tab navigation with action context
-    trackFeatureUsage('navigation', 'tab_change', {
-      component: `${previousTab}_to_${tabId}`,
-      success: true
-    });
-    
-    trackPageView(`/gui/${tabId}`);
-    
-    // Handle specific actions when navigating to tabs
-    if (action) {
-      setTimeout(() => {
-        const event = new CustomEvent(`tab-${tabId}-action`, {
-          detail: { action, metadata }
-        });
-        window.dispatchEvent(event);
-      }, 100); // Allow tab to render first
-    }
-  }, [activeTab, trackFeatureUsage, trackPageView]);
+  const handleTabChange = useCallback(
+    (tabId: string, action?: string, metadata?: any) => {
+      setActiveTab(previousTab => {
+        if (previousTab !== tabId) {
+          trackFeatureUsage('navigation', 'tab_change', {
+            component: `${previousTab}_to_${tabId}`,
+            success: true
+          });
+        }
+
+        return tabId;
+      });
+
+      trackPageView(`/gui/${tabId}`);
+
+      if (action) {
+        setTimeout(() => {
+          const event = new CustomEvent(`tab-${tabId}-action`, {
+            detail: { action, metadata }
+          });
+          window.dispatchEvent(event);
+        }, 100);
+      }
+    },
+    [trackFeatureUsage, trackPageView]
+  );
+
+  const handleTabChangeRef = useRef(handleTabChange);
+
+  useEffect(() => {
+    handleTabChangeRef.current = handleTabChange;
+  }, [handleTabChange]);
+
+  useEffect(() => {
+    const navigateToAnchor = () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      const hash = window.location.hash.replace('#', '');
+      if (!hash) {
+        return;
+      }
+
+      const targetTab = ANCHOR_TAB_MAP[hash];
+
+      if (targetTab) {
+        handleTabChangeRef.current(targetTab);
+        setTimeout(() => {
+          const element = document.getElementById(hash);
+          if (element) {
+            element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          }
+        }, 350);
+      } else {
+        const element = document.getElementById(hash);
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      }
+    };
+
+    navigateToAnchor();
+
+    window.addEventListener('hashchange', navigateToAnchor);
+    return () => window.removeEventListener('hashchange', navigateToAnchor);
+  }, []);
   
   // Listen for custom navigation events from dashboard buttons
   useEffect(() => {
@@ -617,6 +694,15 @@ export default function CortexGUIInterface() {
   
   const visibleTabs = getVisibleTabs();
   const ActiveComponentClass = visibleTabs.find(tab => tab.id === activeTab)?.component || POVDashboard;
+
+  useEffect(() => {
+    if (!visibleTabs.some(tab => tab.id === activeTab)) {
+      const fallbackTab = visibleTabs[0]?.id ?? DEFAULT_TAB_ID;
+      if (fallbackTab && fallbackTab !== activeTab) {
+        setActiveTab(fallbackTab);
+      }
+    }
+  }, [visibleTabs, activeTab]);
   
   // Create component with props for POVDashboard
   const ActiveComponent = () => {

--- a/hosting/components/EnhancedAIAssistant.tsx
+++ b/hosting/components/EnhancedAIAssistant.tsx
@@ -785,10 +785,19 @@ Could you be more specific about what you'd like help with? I can provide detail
   );
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white p-6">
+    <section
+      id="ai-advisor-console"
+      aria-labelledby="ai-advisor-console-heading"
+      className="min-h-screen bg-gray-950 text-white p-6 scroll-mt-28"
+    >
       <div className="max-w-7xl mx-auto">
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-blue-400 mb-2">🤖 Enhanced AI Assistant</h1>
+          <h1
+            id="ai-advisor-console-heading"
+            className="text-3xl font-bold text-blue-400 mb-2"
+          >
+            🤖 Enhanced AI Assistant
+          </h1>
           <p className="text-cortex-text-secondary">Your intelligent companion for Cortex DC success - context-aware, workflow-integrated, and action-oriented</p>
         </div>
 
@@ -823,6 +832,6 @@ Could you be more specific about what you'd like help with? I can provide detail
           {activeTab === 'history' && <HistoryTab />}
         </div>
       </div>
-    </div>
+    </section>
   );
 };

--- a/hosting/components/EnhancedManualCreationGUI.tsx
+++ b/hosting/components/EnhancedManualCreationGUI.tsx
@@ -109,6 +109,7 @@ const POV_SCHEMA: FormSchema = {
   ]
 };
 
+
 const TEMPLATE_SCHEMA: FormSchema = {
   title: 'Create New Template',
   description: 'Reusable Scenario Template',
@@ -653,14 +654,23 @@ export const EnhancedManualCreationGUI: React.FC = () => {
 
   // Main Dashboard
   return (
-    <div className="space-y-8 p-8">
+    <section
+      id="demo-blueprint-studio"
+      aria-labelledby="demo-blueprint-studio-heading"
+      className="space-y-8 p-8 scroll-mt-28"
+    >
       {/* Header */}
       <div className="glass-card p-8">
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center space-x-4">
             <div className="text-4xl">🛠️</div>
             <div>
-              <h1 className="text-3xl font-bold text-cortex-text-primary">Enhanced Creation Studio</h1>
+              <h1
+                id="demo-blueprint-studio-heading"
+                className="text-3xl font-bold text-cortex-text-primary"
+              >
+                Enhanced Creation Studio
+              </h1>
               <p className="text-cortex-text-muted mt-2">Notion-inspired interface for creating POVs, templates, and scenarios</p>
             </div>
           </div>
@@ -812,7 +822,7 @@ export const EnhancedManualCreationGUI: React.FC = () => {
           </ul>
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/hosting/components/ManagementDashboard.tsx
+++ b/hosting/components/ManagementDashboard.tsx
@@ -707,11 +707,20 @@ export const ManagementDashboard: React.FC = () => {
   );
 
   return (
-    <div className="p-8 space-y-8">
+    <section
+      id="management-control-center"
+      aria-labelledby="management-control-center-heading"
+      className="p-8 space-y-8 scroll-mt-28"
+    >
       <div className="glass-card p-8">
         {/* Header */}
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-cortex-text-primary mb-2">⚙️ Management Dashboard</h1>
+          <h1
+            id="management-control-center-heading"
+            className="text-3xl font-bold text-cortex-text-primary mb-2"
+          >
+            ⚙️ Management Dashboard
+          </h1>
           <p className="text-cortex-text-muted">Comprehensive system oversight and user management</p>
           {isLoading && (
             <div className="mt-2 text-yellow-400 text-sm">🔄 Refreshing data...</div>
@@ -814,6 +823,6 @@ export const ManagementDashboard: React.FC = () => {
           </div>
         )}
       </div>
-    </div>
+    </section>
   );
 };

--- a/hosting/components/POVProjectManagement.tsx
+++ b/hosting/components/POVProjectManagement.tsx
@@ -740,11 +740,20 @@ export const POVProjectManagement: React.FC = () => {
   };
 
   return (
-    <div className="p-8 space-y-8">
+    <section
+      id="pov-planning-hub"
+      aria-labelledby="pov-planning-hub-heading"
+      className="p-8 space-y-8 scroll-mt-28"
+    >
       <div className="glass-card p-8">
         <div className="flex items-center justify-between mb-8">
           <div>
-            <h1 className="text-3xl font-bold text-cortex-text-primary mb-2">POV Project Management</h1>
+            <h1
+              id="pov-planning-hub-heading"
+              className="text-3xl font-bold text-cortex-text-primary mb-2"
+            >
+              POV Project Management
+            </h1>
             <p className="text-cortex-text-muted">Comprehensive POV lifecycle management with AI-powered optimization</p>
           </div>
         </div>
@@ -796,6 +805,6 @@ export const POVProjectManagement: React.FC = () => {
           {activeTab === 'analytics' && <div className="text-center py-12"><div className="text-cortex-text-muted">Analytics coming soon...</div></div>}
         </div>
       </div>
-    </div>
+    </section>
   );
 };

--- a/hosting/components/ProductionTRRManagement.tsx
+++ b/hosting/components/ProductionTRRManagement.tsx
@@ -475,7 +475,25 @@ export const ProductionTRRManagement: React.FC = () => {
   );
 
   const ManageTab = () => (
-    <div className="space-y-6">
+    <section
+      id="notes-workbench"
+      aria-labelledby="notes-workbench-heading"
+      className="space-y-6 scroll-mt-28"
+    >
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <h3 id="notes-workbench-heading" className="text-2xl font-semibold text-white flex items-center gap-2">
+            📝 Notes Workbench
+          </h3>
+          <p className="text-sm text-cortex-text-secondary mt-1">
+            Centralized workspace for TRR notes, validation evidence, and follow-up actions.
+          </p>
+        </div>
+        <div className="flex items-center text-xs text-cortex-text-muted bg-gray-800/60 border border-gray-700 rounded px-3 py-2">
+          Live collaboration enabled
+        </div>
+      </div>
+
       {/* Filters and Search */}
       <div className="bg-gray-900/50 p-4 rounded border border-gray-700">
         <div className="flex flex-wrap items-center gap-4">
@@ -651,7 +669,7 @@ export const ProductionTRRManagement: React.FC = () => {
           </div>
         )}
       </div>
-    </div>
+    </section>
   );
 
   const CreateTab = () => (

--- a/hosting/components/UnifiedContentCreator.tsx
+++ b/hosting/components/UnifiedContentCreator.tsx
@@ -1133,10 +1133,19 @@ export const UnifiedContentCreator: React.FC<ScenarioCreatorProps> = ({
   };
 
   const renderOverview = () => (
-    <div className="space-y-6">
+    <section
+      id="content-intelligence-library"
+      aria-labelledby="content-intelligence-library-heading"
+      className="space-y-6 scroll-mt-28"
+    >
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-cortex-text-primary">POV Detection Scenarios</h1>
+          <h1
+            id="content-intelligence-library-heading"
+            className="text-3xl font-bold text-cortex-text-primary"
+          >
+            POV Detection Scenarios
+          </h1>
           <p className="text-cortex-text-secondary mt-1">
             Comprehensive library of {Object.keys(POV_DETECTION_SCENARIOS).length} security scenarios for proof-of-value demonstrations
           </p>
@@ -1252,7 +1261,7 @@ export const UnifiedContentCreator: React.FC<ScenarioCreatorProps> = ({
           <p className="text-cortex-text-secondary">Try adjusting your search terms or filters.</p>
         </div>
       )}
-    </div>
+    </section>
   );
 
   const renderDetail = () => {

--- a/hosting/components/XSIAMHealthMonitor.tsx
+++ b/hosting/components/XSIAMHealthMonitor.tsx
@@ -684,11 +684,20 @@ export const XSIAMHealthMonitor: React.FC = () => {
   );
 
   return (
-    <div className="p-8 space-y-8">
+    <section
+      id="platform-health-monitor"
+      aria-labelledby="platform-health-monitor-heading"
+      className="p-8 space-y-8 scroll-mt-28"
+    >
       <div className="glass-card p-8">
         <div className="flex items-center justify-between mb-8">
           <div>
-            <h1 className="text-3xl font-bold text-cortex-text-primary mb-2">XSIAM Health Monitor</h1>
+            <h1
+              id="platform-health-monitor-heading"
+              className="text-3xl font-bold text-cortex-text-primary mb-2"
+            >
+              XSIAM Health Monitor
+            </h1>
             <p className="text-cortex-text-muted">Real-time system health monitoring with intelligent alerting and automated troubleshooting</p>
           </div>
           <div className="flex items-center space-x-4">
@@ -759,6 +768,6 @@ export const XSIAMHealthMonitor: React.FC = () => {
           {activeTab === 'settings' && <SettingsTab />}
         </div>
       </div>
-    </div>
+    </section>
   );
 };


### PR DESCRIPTION
## Summary
- create shared workspace metadata and capability link definitions for the dynamic workspace route
- add a dynamic `/workspaces/[workspace]` page that loads the Cortex GUI with the appropriate tab and default anchor
- add anchor sections with scroll margin to each workspace module and update the Cortex GUI to open tabs and scroll for hash links

## Testing
- npm run lint *(fails: script not defined in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e7ee0b2f18832682bdc0e238d1a195