### PR TITLE
Refactor TRR/POV data access to use user-scoped Firestore storage

### DIFF
--- a/hosting/components/BigQueryExplorer.tsx
+++ b/hosting/components/BigQueryExplorer.tsx
@@ -6,8 +6,8 @@
 
 import React, { useState, useEffect } from 'react';
 import { useAppState } from '../contexts/AppStateContext';
-import { dcAPIClient, DataExportConfig } from '../lib/dc-api-client';
-import { dcContextStore } from '../lib/dc-context-store';
+import { dcAPIClient, DataExportConfig, UserScopeContext } from '../lib/dc-api-client';
+import { dcContextStore, UserProfile } from '../lib/dc-context-store';
 
 interface ExportJob {
   id: string;
@@ -44,13 +44,34 @@ export const BigQueryExplorer: React.FC = () => {
   });
 
   useEffect(() => {
-    // Initialize sample data if empty
-    if (dcContextStore.getAllCustomerEngagements().length === 0) {
-      dcContextStore.initializeSampleData();
-    }
-    
+    const ensureData = async () => {
+      if (!state.auth.user) {
+        return;
+      }
+
+      const context: UserScopeContext = {
+        userId: state.auth.user.id,
+        scope: state.auth.user.role === 'manager' || state.auth.user.role === 'admin' ? 'team' : 'self',
+        teamUserIds: state.auth.user.assignedProjects || []
+      };
+
+      const profile: UserProfile = {
+        id: state.auth.user.id,
+        name: state.auth.user.username || state.auth.user.email || 'Team Member',
+        email: state.auth.user.email || `${state.auth.user.username || 'user'}@henryreed.ai`,
+        role: (state.auth.user.role === 'manager' || state.auth.user.role === 'admin') ? 'manager' : 'dc',
+        region: 'AMER',
+        specializations: state.auth.user.assignedProjects || [],
+        createdAt: state.auth.user.lastLogin || new Date().toISOString(),
+        lastActive: new Date().toISOString()
+      };
+
+      await dcAPIClient.ensureStarterDataForUser(context, profile);
+    };
+
+    ensureData();
     loadExportHistory();
-  }, [actions]);
+  }, [actions, state.auth.user]);
 
   const loadExportHistory = () => {
     // Mock export history - in production, this would load from API

--- a/hosting/components/EnhancedAIAssistant.tsx
+++ b/hosting/components/EnhancedAIAssistant.tsx
@@ -6,8 +6,8 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { useAppState } from '../contexts/AppStateContext';
-import { dcAPIClient } from '../lib/dc-api-client';
-import { dcContextStore } from '../lib/dc-context-store';
+import { dcAPIClient, UserScopeContext } from '../lib/dc-api-client';
+import { dcContextStore, UserProfile } from '../lib/dc-context-store';
 import { dcAIClient, DCWorkflowContext } from '../lib/dc-ai-client';
 
 interface AIMessage {
@@ -64,15 +64,35 @@ export const EnhancedAIAssistant: React.FC = () => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    
-    // Initialize sample data if empty
-    if (dcContextStore.getAllCustomerEngagements().length === 0) {
-      dcContextStore.initializeSampleData();
-    }
-    
+    const ensureData = async () => {
+      if (!state.auth.user) {
+        return;
+      }
+
+      const context: UserScopeContext = {
+        userId: state.auth.user.id,
+        scope: state.auth.user.role === 'manager' || state.auth.user.role === 'admin' ? 'team' : 'self',
+        teamUserIds: state.auth.user.assignedProjects || []
+      };
+
+      const profile: UserProfile = {
+        id: state.auth.user.id,
+        name: state.auth.user.username || state.auth.user.email || 'Team Member',
+        email: state.auth.user.email || `${state.auth.user.username || 'user'}@henryreed.ai`,
+        role: (state.auth.user.role === 'manager' || state.auth.user.role === 'admin') ? 'manager' : 'dc',
+        region: 'AMER',
+        specializations: state.auth.user.assignedProjects || [],
+        createdAt: state.auth.user.lastLogin || new Date().toISOString(),
+        lastActive: new Date().toISOString()
+      };
+
+      await dcAPIClient.ensureStarterDataForUser(context, profile);
+    };
+
+    ensureData();
     initializeAssistant();
     loadInsights();
-  }, [actions]);
+  }, [actions, state.auth.user]);
 
   useEffect(() => {
     scrollToBottom();

--- a/hosting/components/POVProjectManagement.tsx
+++ b/hosting/components/POVProjectManagement.tsx
@@ -4,10 +4,10 @@
  * Comprehensive POV lifecycle management with scenario planning, timeline tracking, and outcome reporting
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAppState } from '../contexts/AppStateContext';
-import { dcAPIClient } from '../lib/dc-api-client';
-import { dcContextStore, ActivePOV as POVRecord, CustomerEngagement } from '../lib/dc-context-store';
+import { dcAPIClient, UserScopeContext } from '../lib/dc-api-client';
+import { dcContextStore, ActivePOV as POVRecord, CustomerEngagement, UserProfile } from '../lib/dc-context-store';
 import { dcAIClient, DCWorkflowContext } from '../lib/dc-ai-client';
 
 interface POVScenario {
@@ -87,14 +87,87 @@ export const POVProjectManagement: React.FC = () => {
       milestones: []
     }
   });
+  const [povList, setPovList] = useState<POVRecord[]>([]);
+  const [isSeeding, setIsSeeding] = useState(false);
+
+  const buildUserContext = useCallback((): UserScopeContext | null => {
+    if (!state.auth.user) {
+      return null;
+    }
+
+    const isManager = state.auth.user.role === 'manager' || state.auth.user.role === 'admin';
+
+    return {
+      userId: state.auth.user.id,
+      scope: isManager ? 'team' : 'self',
+      teamUserIds: isManager ? state.auth.user.assignedProjects || [] : undefined
+    };
+  }, [state.auth.user]);
+
+  const onboardingProfile = useMemo<UserProfile | null>(() => {
+    if (!state.auth.user) {
+      return null;
+    }
+
+    const roleMap: Record<string, UserProfile['role']> = {
+      admin: 'manager',
+      manager: 'manager',
+      senior_dc: 'dc',
+      dc: 'dc',
+      analyst: 'dc'
+    };
+
+    return {
+      id: state.auth.user.id,
+      name: state.auth.user.username || state.auth.user.email || 'Team Member',
+      email: state.auth.user.email || `${state.auth.user.username || 'user'}@henryreed.ai`,
+      role: roleMap[state.auth.user.role] || 'dc',
+      region: 'AMER',
+      specializations: state.auth.user.assignedProjects || [],
+      createdAt: state.auth.user.lastLogin || new Date().toISOString(),
+      lastActive: new Date().toISOString()
+    };
+  }, [state.auth.user]);
+
+  const reloadPOVs = useCallback(async (contextOverride?: UserScopeContext) => {
+    const context = contextOverride || buildUserContext();
+    if (!context || !state.auth.user) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      let response = await dcAPIClient.getPOVs(context);
+      let povs = response.success && response.data ? response.data : [];
+
+      if (povs.length === 0 && onboardingProfile) {
+        setIsSeeding(true);
+        await dcAPIClient.ensureStarterDataForUser(context, onboardingProfile);
+        response = await dcAPIClient.getPOVs(context);
+        if (response.success && response.data) {
+          povs = response.data;
+        }
+      }
+
+      setPovList(povs);
+      if (selectedPOV) {
+        const refreshed = povs.find(p => p.id === selectedPOV.id);
+        if (refreshed) {
+          setSelectedPOV(refreshed);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load POVs:', error);
+      actions.notify('error', 'Failed to load POV projects');
+    } finally {
+      setIsLoading(false);
+      setIsSeeding(false);
+    }
+  }, [actions, buildUserContext, onboardingProfile, selectedPOV, state.auth.user]);
 
   useEffect(() => {
-    
-    // Initialize sample data if empty
-    if (dcContextStore.getAllCustomerEngagements().length === 0) {
-      dcContextStore.initializeSampleData();
-    }
-  }, [actions]);
+    reloadPOVs();
+  }, [reloadPOVs]);
 
   const povTemplates: POVTemplate[] = [
     {
@@ -160,11 +233,17 @@ export const POVProjectManagement: React.FC = () => {
   ];
 
   const customers = dcContextStore.getAllCustomerEngagements();
-  const povs = dcContextStore.getAllActivePOVs();
+  const povs = povList.length > 0 ? povList : dcContextStore.getAllActivePOVs();
 
   const handleCreatePOV = async () => {
     if (!formData.name || !formData.customerId) {
       actions.notify('error', 'Please provide POV name and select a customer');
+      return;
+    }
+
+    const context = buildUserContext();
+    if (!context) {
+      actions.notify('error', 'Active user context unavailable');
       return;
     }
 
@@ -199,7 +278,7 @@ export const POVProjectManagement: React.FC = () => {
         nextSteps: []
       };
 
-      const response = await dcAPIClient.createPOV(povData);
+      const response = await dcAPIClient.createPOV(context, povData);
       if (response.success && response.data) {
         actions.notify('success', `POV "${formData.name}" created successfully`);
         setShowCreateForm(false);
@@ -212,6 +291,7 @@ export const POVProjectManagement: React.FC = () => {
           risks: [],
           timeline: { start: '', end: '', milestones: [] }
         });
+        reloadPOVs(context);
       } else {
         actions.notify('error', response.error || 'Failed to create POV');
       }
@@ -309,6 +389,11 @@ export const POVProjectManagement: React.FC = () => {
     <div className="space-y-8">
       {/* POV Overview */}
       <div className="glass-card p-6">
+        {isLoading && (
+          <div className="mb-3 text-sm text-cortex-text-muted">
+            {isSeeding ? 'Preparing starter POVs for your workspace...' : 'Loading POV data...'}
+          </div>
+        )}
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-xl font-bold text-cortex-text-primary">🎯 POV Portfolio Overview</h3>
           <button

--- a/hosting/components/ProductionTRRManagement.tsx
+++ b/hosting/components/ProductionTRRManagement.tsx
@@ -5,10 +5,10 @@
  * and comprehensive reporting. Full data persistence and workflow automation.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAppState } from '../contexts/AppStateContext';
-import { dcAPIClient } from '../lib/dc-api-client';
-import { dcContextStore, TRRRecord, CustomerEngagement, ActivePOV } from '../lib/dc-context-store';
+import { dcAPIClient, UserScopeContext } from '../lib/dc-api-client';
+import { dcContextStore, TRRRecord, CustomerEngagement, ActivePOV, UserProfile } from '../lib/dc-context-store';
 import { dcAIClient, DCWorkflowContext } from '../lib/dc-ai-client';
 import { SolutionDesignWorkbook } from '../lib/sdw-models';
 import { SDWWorkflow } from './SDWWorkflow';
@@ -73,32 +73,98 @@ export const ProductionTRRManagement: React.FC = () => {
   const [showSDWWorkflow, setShowSDWWorkflow] = useState(false);
   const [selectedTRRForSDW, setSelectedTRRForSDW] = useState<string | null>(null);
   const [sdwList, setSDWList] = useState<Record<string, SolutionDesignWorkbook>>({});
+  const [povList, setPovList] = useState<POVRecord[]>([]);
+  const [isSeeding, setIsSeeding] = useState(false);
 
-  useEffect(() => {
-    
-    // Initialize sample data if empty
-    if (dcContextStore.getAllCustomerEngagements().length === 0) {
-      dcContextStore.initializeSampleData();
+  const buildUserContext = useCallback((): UserScopeContext | null => {
+    if (!state.auth.user) {
+      return null;
     }
-    
-    loadTRRs();
-    initializeWorkflowTemplates();
-  }, [actions]);
 
-  const loadTRRs = async () => {
+    const isManager = state.auth.user.role === 'manager' || state.auth.user.role === 'admin';
+
+    return {
+      userId: state.auth.user.id,
+      scope: isManager ? 'team' : 'self',
+      teamUserIds: isManager ? state.auth.user.assignedProjects || [] : undefined
+    };
+  }, [state.auth.user]);
+
+  const onboardingProfile = useMemo<UserProfile | null>(() => {
+    if (!state.auth.user) {
+      return null;
+    }
+
+    const roleMap: Record<string, UserProfile['role']> = {
+      admin: 'manager',
+      manager: 'manager',
+      senior_dc: 'dc',
+      dc: 'dc',
+      analyst: 'dc'
+    };
+
+    return {
+      id: state.auth.user.id,
+      name: state.auth.user.username || state.auth.user.email || 'Team Member',
+      email: state.auth.user.email || `${state.auth.user.username || 'user'}@henryreed.ai`,
+      role: roleMap[state.auth.user.role] || 'dc',
+      region: 'AMER',
+      specializations: state.auth.user.assignedProjects || [],
+      createdAt: state.auth.user.lastLogin || new Date().toISOString(),
+      lastActive: new Date().toISOString()
+    };
+  }, [state.auth.user]);
+
+  const reloadData = useCallback(async (contextOverride?: UserScopeContext) => {
+    const context = contextOverride || buildUserContext();
+    if (!context || !state.auth.user) {
+      return;
+    }
+
     setIsLoading(true);
     try {
-      const response = await dcAPIClient.getTRRs();
-      if (response.success && response.data) {
-        setTrrList(response.data);
+      const [trrResponse, povResponse] = await Promise.all([
+        dcAPIClient.getTRRs(context),
+        dcAPIClient.getPOVs(context)
+      ]);
+
+      let trrs = trrResponse.success && trrResponse.data ? trrResponse.data : [];
+      let povs = povResponse.success && povResponse.data ? povResponse.data : [];
+
+      if (trrs.length === 0 && povs.length === 0 && onboardingProfile) {
+        setIsSeeding(true);
+        await dcAPIClient.ensureStarterDataForUser(context, onboardingProfile);
+        const [seededTRRs, seededPOVs] = await Promise.all([
+          dcAPIClient.getTRRs(context),
+          dcAPIClient.getPOVs(context)
+        ]);
+
+        if (seededTRRs.success && seededTRRs.data) {
+          trrs = seededTRRs.data;
+        }
+        if (seededPOVs.success && seededPOVs.data) {
+          povs = seededPOVs.data;
+        }
       }
+
+      setTrrList(trrs);
+      setPovList(povs);
     } catch (error) {
-      console.error('Failed to load TRRs:', error);
-      actions.notify('error', 'Failed to load TRRs');
+      console.error('Failed to load TRR data:', error);
+      actions.notify('error', 'Failed to load TRR data');
     } finally {
       setIsLoading(false);
+      setIsSeeding(false);
     }
-  };
+  }, [actions, buildUserContext, onboardingProfile, state.auth.user]);
+
+  useEffect(() => {
+    initializeWorkflowTemplates();
+  }, []);
+
+  useEffect(() => {
+    reloadData();
+  }, [reloadData]);
 
   const initializeWorkflowTemplates = () => {
     const defaultSteps: TRRWorkflowStep[] = [
@@ -158,6 +224,12 @@ export const ProductionTRRManagement: React.FC = () => {
       return;
     }
 
+    const context = buildUserContext();
+    if (!context) {
+      actions.notify('error', 'Active user context unavailable');
+      return;
+    }
+
     setIsLoading(true);
     try {
       const trrData: Omit<TRRRecord, 'id' | 'createdAt' | 'updatedAt'> = {
@@ -171,7 +243,7 @@ export const ProductionTRRManagement: React.FC = () => {
         acceptanceCriteria: formData.acceptanceCriteria || [],
         validationMethod: formData.validationMethod || 'Technical review',
         validationEvidence: [],
-        assignedTo: formData.assignedTo || 'Domain Consultant',
+        assignedTo: formData.assignedTo || onboardingProfile?.name || state.auth.user?.username || 'Domain Consultant',
         reviewers: formData.reviewers || [],
         timeline: {
           created: new Date().toISOString(),
@@ -185,7 +257,7 @@ export const ProductionTRRManagement: React.FC = () => {
         notes: formData.notes || []
       };
 
-      const response = await dcAPIClient.createTRR(trrData);
+      const response = await dcAPIClient.createTRR(context, trrData);
       if (response.success) {
         actions.notify('success', `TRR "${formData.title}" created successfully`);
         setShowCreateForm(false);
@@ -195,7 +267,7 @@ export const ProductionTRRManagement: React.FC = () => {
           dependencies: [],
           notes: []
         });
-        loadTRRs();
+        reloadData(context);
       } else {
         actions.notify('error', response.error || 'Failed to create TRR');
       }
@@ -208,12 +280,20 @@ export const ProductionTRRManagement: React.FC = () => {
   };
 
   const handleValidateTRR = async (trrId: string, evidence?: string[]) => {
+    const context = buildUserContext();
+    if (!context) {
+      actions.notify('error', 'Active user context unavailable');
+      return;
+    }
+
+    const trr = trrList.find(t => t.id === trrId);
+
     setIsLoading(true);
     try {
-      const response = await dcAPIClient.validateTRR(trrId, evidence);
+      const response = await dcAPIClient.validateTRR(context, trrId, evidence, trr?.ownerId);
       if (response.success) {
         actions.notify('success', 'TRR validated successfully');
-        loadTRRs();
+        reloadData(context);
       } else {
         actions.notify('error', response.error || 'Failed to validate TRR');
       }
@@ -229,16 +309,22 @@ export const ProductionTRRManagement: React.FC = () => {
     const trr = trrList.find(t => t.id === trrId);
     if (!trr) return;
 
+    const context = buildUserContext();
+    if (!context) {
+      actions.notify('error', 'Active user context unavailable');
+      return;
+    }
+
     const updates: Partial<TRRRecord> = {
       status: newStatus,
       notes: [...trr.notes, `Status updated to ${newStatus} at ${new Date().toLocaleString()}`]
     };
 
     try {
-      const response = await dcAPIClient.updateTRR(trrId, updates);
+      const response = await dcAPIClient.updateTRR(context, trrId, updates, trr.ownerId);
       if (response.success) {
         actions.notify('success', `TRR status updated to ${newStatus}`);
-        loadTRRs();
+        reloadData(context);
       } else {
         actions.notify('error', 'Failed to update TRR status');
       }
@@ -281,21 +367,26 @@ export const ProductionTRRManagement: React.FC = () => {
   const handleSaveSDW = async (sdw: SolutionDesignWorkbook) => {
     // Store SDW in local state (in production, this would go to API/database)
     setSDWList(prev => ({ ...prev, [sdw.trrId]: sdw }));
-    
+
     // Update TRR to reference the SDW
     const updates: Partial<TRRRecord> = {
       notes: [...(selectedTRR?.notes || []), `Solution Design Workbook created: ${sdw.id}`]
     };
-    
+
     if (selectedTRRForSDW) {
+      const context = buildUserContext();
       try {
-        await dcAPIClient.updateTRR(selectedTRRForSDW, updates);
-        loadTRRs();
+        if (!context) {
+          throw new Error('Active user context unavailable');
+        }
+        const targetTRR = trrList.find(t => t.id === selectedTRRForSDW);
+        await dcAPIClient.updateTRR(context, selectedTRRForSDW, updates, targetTRR?.ownerId);
+        reloadData(context);
       } catch (error) {
         console.error('Failed to update TRR with SDW reference:', error);
       }
     }
-    
+
     setShowSDWWorkflow(false);
     setSelectedTRRForSDW(null);
   };
@@ -306,7 +397,7 @@ export const ProductionTRRManagement: React.FC = () => {
   };
 
   const customers = dcContextStore.getAllCustomerEngagements();
-  const povs = dcContextStore.getAllActivePOVs();
+  const povs = povList.length > 0 ? povList : dcContextStore.getAllActivePOVs();
 
   // Filter and search logic
   const filteredTRRs = trrList.filter(trr => {
@@ -530,7 +621,9 @@ export const ProductionTRRManagement: React.FC = () => {
         {isLoading ? (
           <div className="text-center py-8">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-400 mx-auto mb-2"></div>
-            <div className="text-cortex-text-secondary">Loading TRRs...</div>
+            <div className="text-cortex-text-secondary">
+              {isSeeding ? 'Preparing starter TRRs for your workspace...' : 'Loading TRRs...'}
+            </div>
           </div>
         ) : filteredTRRs.length === 0 ? (
           <div className="text-center py-8">

--- a/hosting/lib/dc-api-client.ts
+++ b/hosting/lib/dc-api-client.ts
@@ -3,9 +3,22 @@
  * Comprehensive API layer for all DC workflows and operations
  */
 
-import { dcContextStore, CustomerEngagement, ActivePOV as POVRecord, TRRRecord, WorkflowHistory as WorkflowHistoryEntry } from './dc-context-store';
+import { dcContextStore, CustomerEngagement, ActivePOV as POVRecord, TRRRecord, WorkflowHistory as WorkflowHistoryEntry, UserProfile } from './dc-context-store';
 import { dcAIClient, DCWorkflowContext } from './dc-ai-client';
 import { SolutionDesignWorkbook, SDWExportConfiguration } from './sdw-models';
+import getFirebaseServices from './firebase/client';
+import {
+  addDoc,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  updateDoc,
+  where,
+  setDoc
+} from 'firebase/firestore';
+import type { QueryConstraint } from 'firebase/firestore';
 
 // API Response Types
 export interface APIResponse<T = any> {
@@ -84,6 +97,13 @@ export interface KnowledgeBaseEntry {
   searchable: boolean;
 }
 
+export interface UserScopeContext {
+  userId: string;
+  scope?: 'self' | 'team';
+  teamUserIds?: string[];
+  targetUserId?: string;
+}
+
 /**
  * Main DC API Client
  */
@@ -95,6 +115,39 @@ export class DCAPIClient {
   constructor(baseUrl: string = '/api/dc', apiKey?: string) {
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;
+  }
+
+  private getFirestore() {
+    try {
+      const { firestore } = getFirebaseServices();
+      return firestore;
+    } catch (error) {
+      console.warn('Firestore unavailable, using context store fallback:', error);
+      return null;
+    }
+  }
+
+  private resolveUserIds(context: UserScopeContext): string[] {
+    const ids = new Set<string>();
+    if (context.userId) {
+      ids.add(context.userId);
+    }
+    if (context.scope === 'team' && context.teamUserIds) {
+      context.teamUserIds.filter(Boolean).forEach(id => ids.add(id));
+    }
+    return Array.from(ids);
+  }
+
+  private ensureTeamScope(context: UserScopeContext, targetUserId: string) {
+    if (targetUserId && targetUserId !== context.userId) {
+      if (context.scope !== 'team') {
+        throw new Error('Insufficient permissions to modify team member records');
+      }
+      const allowed = this.resolveUserIds(context);
+      if (!allowed.includes(targetUserId)) {
+        throw new Error('Target user not within team scope');
+      }
+    }
   }
 
   private async request<T>(endpoint: string, options: RequestInit = {}): Promise<APIResponse<T>> {
@@ -176,128 +229,400 @@ export class DCAPIClient {
   }
 
   // POV Management
-  async getPOVs(customerId?: string): Promise<APIResponse<POVRecord[]>> {
-    const povs = customerId 
-      ? dcContextStore.getAllActivePOVs().filter(p => p.customerId === customerId)
-      : dcContextStore.getAllActivePOVs();
+  async getPOVs(context: UserScopeContext, filters?: { customerId?: string; status?: string }): Promise<APIResponse<POVRecord[]>> {
+    const firestore = this.getFirestore();
+    try {
+      const povs: POVRecord[] = [];
+      const userIds = this.resolveUserIds(context);
 
-    return {
-      success: true,
-      data: povs,
-      timestamp: new Date().toISOString(),
-      requestId: `req_${Date.now()}_local`
-    };
+      if (firestore) {
+        for (const userId of userIds) {
+          let povQuery: any = collection(firestore, 'users', userId, 'povs');
+          const constraints: QueryConstraint[] = [];
+
+          if (filters?.customerId) {
+            constraints.push(where('customerId', '==', filters.customerId));
+          }
+          if (filters?.status) {
+            constraints.push(where('status', '==', filters.status));
+          }
+
+          if (constraints.length > 0) {
+            povQuery = query(povQuery, ...constraints);
+          }
+
+          const snapshot = await getDocs(povQuery);
+          snapshot.forEach(docSnap => {
+            const data = docSnap.data() as POVRecord;
+            povs.push({ ...data, id: docSnap.id, ownerId: data.ownerId || userId });
+            dcContextStore.addActivePOV({ ...data, id: docSnap.id, ownerId: data.ownerId || userId });
+          });
+        }
+      } else {
+        const stored = dcContextStore.getAllActivePOVs();
+        const allowedIds = new Set(userIds);
+        stored
+          .filter(pov => !pov.ownerId || allowedIds.has(pov.ownerId))
+          .filter(pov => {
+            if (filters?.customerId && pov.customerId !== filters.customerId) return false;
+            if (filters?.status && pov.status !== filters.status) return false;
+            return true;
+          })
+          .forEach(pov => povs.push(pov));
+      }
+
+      povs.sort((a, b) => new Date(b.updatedAt || b.createdAt || '').getTime() - new Date(a.updatedAt || a.createdAt || '').getTime());
+
+      return {
+        success: true,
+        data: povs,
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_povs`
+      };
+    } catch (error: any) {
+      console.error('Failed to fetch POVs:', error);
+      return {
+        success: false,
+        error: error.message || 'Failed to fetch POVs',
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_povs_error`
+      };
+    }
   }
 
-  async createPOV(pov: Omit<POVRecord, 'id' | 'createdAt' | 'updatedAt'>): Promise<APIResponse<POVRecord>> {
-    const newPOV: POVRecord = {
-      ...pov,
-      id: `pov_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
-    };
+  async createPOV(context: UserScopeContext, pov: Omit<POVRecord, 'id' | 'createdAt' | 'updatedAt'>): Promise<APIResponse<POVRecord>> {
+    try {
+      const ownerId = context.targetUserId || context.userId;
+      this.ensureTeamScope(context, ownerId);
 
-    dcContextStore.addActivePOV(newPOV);
-    
-    return {
-      success: true,
-      data: newPOV,
-      timestamp: new Date().toISOString(),
-      requestId: `req_${Date.now()}_local`
-    };
+      const timestamp = new Date().toISOString();
+      const newPOV: POVRecord = {
+        ...pov,
+        ownerId,
+        id: '',
+        createdAt: timestamp,
+        updatedAt: timestamp
+      };
+
+      const firestore = this.getFirestore();
+      if (firestore) {
+        const docRef = await addDoc(collection(firestore, 'users', ownerId, 'povs'), {
+          ...newPOV,
+          id: undefined
+        });
+        newPOV.id = docRef.id;
+      } else {
+        newPOV.id = `pov_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+      }
+
+      dcContextStore.addActivePOV(newPOV);
+
+      if (firestore && newPOV.id) {
+        await updateDoc(doc(firestore, 'users', ownerId, 'povs', newPOV.id), {
+          id: newPOV.id
+        });
+      }
+
+      return {
+        success: true,
+        data: newPOV,
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_pov_create`
+      };
+    } catch (error: any) {
+      console.error('Failed to create POV:', error);
+      return {
+        success: false,
+        error: error.message || 'Failed to create POV',
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_pov_create_error`
+      };
+    }
   }
 
-  async updatePOV(id: string, updates: Partial<POVRecord>): Promise<APIResponse<POVRecord>> {
-    dcContextStore.updateActivePOV(id, updates);
-    const updated = dcContextStore.getActivePOV(id);
-    
-    return {
-      success: !!updated,
-      data: updated,
-      error: updated ? undefined : 'POV not found',
-      timestamp: new Date().toISOString(),
-      requestId: `req_${Date.now()}_local`
-    };
+  async updatePOV(context: UserScopeContext, id: string, updates: Partial<POVRecord>, ownerId?: string): Promise<APIResponse<POVRecord>> {
+    try {
+      const targetOwnerId = ownerId || context.targetUserId || context.userId;
+      this.ensureTeamScope(context, targetOwnerId);
+
+      const firestore = this.getFirestore();
+      let updated: POVRecord | undefined;
+
+      if (firestore) {
+        const docRef = doc(firestore, 'users', targetOwnerId, 'povs', id);
+        await updateDoc(docRef, {
+          ...updates,
+          updatedAt: new Date().toISOString()
+        });
+        const snapshot = await getDoc(docRef);
+        if (snapshot.exists()) {
+          updated = { ...(snapshot.data() as POVRecord), id: snapshot.id, ownerId: targetOwnerId };
+          dcContextStore.updateActivePOV(id, updated);
+        }
+      } else {
+        dcContextStore.updateActivePOV(id, { ...updates, ownerId: targetOwnerId });
+        updated = dcContextStore.getActivePOV(id);
+      }
+
+      return {
+        success: !!updated,
+        data: updated,
+        error: updated ? undefined : 'POV not found',
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_pov_update`
+      };
+    } catch (error: any) {
+      console.error('Failed to update POV:', error);
+      return {
+        success: false,
+        error: error.message || 'Failed to update POV',
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_pov_update_error`
+      };
+    }
   }
 
   // TRR Management
-  async getTRRs(filters?: { customerId?: string; povId?: string; status?: string }): Promise<APIResponse<TRRRecord[]>> {
-    let trrs = dcContextStore.getAllTRRRecords();
-    
-    if (filters) {
-      if (filters.customerId) trrs = trrs.filter(t => t.customerId === filters.customerId);
-      if (filters.povId) trrs = trrs.filter(t => t.povId === filters.povId);
-      if (filters.status) trrs = trrs.filter(t => t.status === filters.status);
-    }
+  async getTRRs(context: UserScopeContext, filters?: { customerId?: string; povId?: string; status?: string }): Promise<APIResponse<TRRRecord[]>> {
+    const firestore = this.getFirestore();
+    try {
+      const trrs: TRRRecord[] = [];
+      const userIds = this.resolveUserIds(context);
 
-    return {
-      success: true,
-      data: trrs,
-      timestamp: new Date().toISOString(),
-      requestId: `req_${Date.now()}_local`
-    };
-  }
+      if (firestore) {
+        for (const userId of userIds) {
+          let trrQuery: any = collection(firestore, 'users', userId, 'trrs');
+          const constraints: QueryConstraint[] = [];
 
-  async createTRR(trr: Omit<TRRRecord, 'id' | 'createdAt' | 'updatedAt'>): Promise<APIResponse<TRRRecord>> {
-    const newTRR: TRRRecord = {
-      ...trr,
-      id: `trr_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
-    };
+          if (filters?.customerId) constraints.push(where('customerId', '==', filters.customerId));
+          if (filters?.povId) constraints.push(where('povId', '==', filters.povId));
+          if (filters?.status) constraints.push(where('status', '==', filters.status));
 
-    dcContextStore.addTRRRecord(newTRR);
-    
-    return {
-      success: true,
-      data: newTRR,
-      timestamp: new Date().toISOString(),
-      requestId: `req_${Date.now()}_local`
-    };
-  }
+          if (constraints.length > 0) {
+            trrQuery = query(trrQuery, ...constraints);
+          }
 
-  async updateTRR(id: string, updates: Partial<TRRRecord>): Promise<APIResponse<TRRRecord>> {
-    dcContextStore.updateTRRRecord(id, updates);
-    const updated = dcContextStore.getTRRRecord(id);
-    
-    return {
-      success: !!updated,
-      data: updated,
-      error: updated ? undefined : 'TRR not found',
-      timestamp: new Date().toISOString(),
-      requestId: `req_${Date.now()}_local`
-    };
-  }
+          const snapshot = await getDocs(trrQuery);
+          snapshot.forEach(docSnap => {
+            const data = docSnap.data() as TRRRecord;
+            const record = { ...data, id: docSnap.id, ownerId: data.ownerId || userId };
+            trrs.push(record);
+            dcContextStore.addTRRRecord(record);
+          });
+        }
+      } else {
+        const stored = dcContextStore.getAllTRRRecords();
+        const allowed = new Set(userIds);
+        stored
+          .filter(trr => !trr.ownerId || allowed.has(trr.ownerId))
+          .filter(trr => {
+            if (filters?.customerId && trr.customerId !== filters.customerId) return false;
+            if (filters?.povId && trr.povId !== filters.povId) return false;
+            if (filters?.status && trr.status !== filters.status) return false;
+            return true;
+          })
+          .forEach(trr => trrs.push(trr));
+      }
 
-  async validateTRR(id: string, evidence?: string[]): Promise<APIResponse<TRRRecord>> {
-    const trr = dcContextStore.getTRRRecord(id);
-    if (!trr) {
+      trrs.sort((a, b) => new Date(b.updatedAt || b.createdAt || '').getTime() - new Date(a.updatedAt || a.createdAt || '').getTime());
+
+      return {
+        success: true,
+        data: trrs,
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_trrs`
+      };
+    } catch (error: any) {
+      console.error('Failed to fetch TRRs:', error);
       return {
         success: false,
-        error: 'TRR not found',
+        error: error.message || 'Failed to fetch TRRs',
         timestamp: new Date().toISOString(),
-        requestId: `req_${Date.now()}_local`
+        requestId: `req_${Date.now()}_trrs_error`
       };
     }
+  }
 
-    const updates: Partial<TRRRecord> = {
-      status: 'validated',
-      timeline: {
-        ...trr.timeline,
-        actualValidation: new Date().toISOString()
-      },
-      validationEvidence: evidence || trr.validationEvidence
-    };
+  async createTRR(context: UserScopeContext, trr: Omit<TRRRecord, 'id' | 'createdAt' | 'updatedAt'>): Promise<APIResponse<TRRRecord>> {
+    try {
+      const ownerId = context.targetUserId || context.userId;
+      this.ensureTeamScope(context, ownerId);
+      const timestamp = new Date().toISOString();
 
-    dcContextStore.updateTRRRecord(id, updates);
-    const updated = dcContextStore.getTRRRecord(id);
-    
-    return {
-      success: true,
-      data: updated!,
-      timestamp: new Date().toISOString(),
-      requestId: `req_${Date.now()}_local`
-    };
+      const newTRR: TRRRecord = {
+        ...trr,
+        ownerId,
+        id: '',
+        createdAt: timestamp,
+        updatedAt: timestamp
+      };
+
+      const firestore = this.getFirestore();
+      if (firestore) {
+        const docRef = await addDoc(collection(firestore, 'users', ownerId, 'trrs'), {
+          ...newTRR,
+          id: undefined
+        });
+        newTRR.id = docRef.id;
+      } else {
+        newTRR.id = `trr_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+      }
+
+      dcContextStore.addTRRRecord(newTRR);
+
+      if (firestore && newTRR.id) {
+        await updateDoc(doc(firestore, 'users', ownerId, 'trrs', newTRR.id), {
+          id: newTRR.id
+        });
+      }
+
+      return {
+        success: true,
+        data: newTRR,
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_trr_create`
+      };
+    } catch (error: any) {
+      console.error('Failed to create TRR:', error);
+      return {
+        success: false,
+        error: error.message || 'Failed to create TRR',
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_trr_create_error`
+      };
+    }
+  }
+
+  async updateTRR(context: UserScopeContext, id: string, updates: Partial<TRRRecord>, ownerId?: string): Promise<APIResponse<TRRRecord>> {
+    try {
+      const targetOwnerId = ownerId || context.targetUserId || context.userId;
+      this.ensureTeamScope(context, targetOwnerId);
+      const firestore = this.getFirestore();
+      let updated: TRRRecord | undefined;
+
+      if (firestore) {
+        const docRef = doc(firestore, 'users', targetOwnerId, 'trrs', id);
+        await updateDoc(docRef, {
+          ...updates,
+          updatedAt: new Date().toISOString()
+        });
+        const snapshot = await getDoc(docRef);
+        if (snapshot.exists()) {
+          updated = { ...(snapshot.data() as TRRRecord), id: snapshot.id, ownerId: targetOwnerId };
+          dcContextStore.updateTRRRecord(id, updated);
+        }
+      } else {
+        dcContextStore.updateTRRRecord(id, { ...updates, ownerId: targetOwnerId });
+        updated = dcContextStore.getTRRRecord(id);
+      }
+
+      return {
+        success: !!updated,
+        data: updated,
+        error: updated ? undefined : 'TRR not found',
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_trr_update`
+      };
+    } catch (error: any) {
+      console.error('Failed to update TRR:', error);
+      return {
+        success: false,
+        error: error.message || 'Failed to update TRR',
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_trr_update_error`
+      };
+    }
+  }
+
+  async validateTRR(context: UserScopeContext, id: string, evidence?: string[], ownerId?: string): Promise<APIResponse<TRRRecord>> {
+    try {
+      const targetOwnerId = ownerId || context.targetUserId || context.userId;
+      this.ensureTeamScope(context, targetOwnerId);
+      const firestore = this.getFirestore();
+
+      let trr = dcContextStore.getTRRRecord(id);
+      if (!trr && firestore) {
+        const docRef = doc(firestore, 'users', targetOwnerId, 'trrs', id);
+        const snapshot = await getDoc(docRef);
+        if (snapshot.exists()) {
+          trr = { ...(snapshot.data() as TRRRecord), id: snapshot.id, ownerId: targetOwnerId };
+          dcContextStore.addTRRRecord(trr);
+        }
+      }
+
+      if (!trr) {
+        return {
+          success: false,
+          error: 'TRR not found',
+          timestamp: new Date().toISOString(),
+          requestId: `req_${Date.now()}_trr_validate_missing`
+        };
+      }
+
+      const updates: Partial<TRRRecord> = {
+        status: 'validated',
+        timeline: {
+          ...trr.timeline,
+          actualValidation: new Date().toISOString()
+        },
+        validationEvidence: evidence || trr.validationEvidence,
+        updatedAt: new Date().toISOString()
+      };
+
+      const updateResult = await this.updateTRR(context, id, updates, trr.ownerId || targetOwnerId);
+
+      if (!updateResult.success || !updateResult.data) {
+        return updateResult;
+      }
+
+      return {
+        success: true,
+        data: updateResult.data,
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_trr_validate`
+      };
+    } catch (error: any) {
+      console.error('Failed to validate TRR:', error);
+      return {
+        success: false,
+        error: error.message || 'Failed to validate TRR',
+        timestamp: new Date().toISOString(),
+        requestId: `req_${Date.now()}_trr_validate_error`
+      };
+    }
+  }
+
+  async ensureStarterDataForUser(context: UserScopeContext, user: UserProfile): Promise<{ seeded: boolean; error?: string }> {
+    try {
+      const firestore = this.getFirestore();
+
+      if (!firestore) {
+        const seeded = dcContextStore.seedStarterDataForUser(user);
+        return { seeded: !!seeded.seeded };
+      }
+
+      const povSnapshot = await getDocs(collection(firestore, 'users', user.id, 'povs'));
+      const trrSnapshot = await getDocs(collection(firestore, 'users', user.id, 'trrs'));
+
+      if (!povSnapshot.empty || !trrSnapshot.empty) {
+        return { seeded: false };
+      }
+
+      const seedResult = dcContextStore.seedStarterDataForUser(user);
+      if (!seedResult.seeded) {
+        return { seeded: false };
+      }
+
+      await setDoc(doc(firestore, 'users', user.id, 'povs', seedResult.pov.id), seedResult.pov);
+      await Promise.all(
+        seedResult.trrs.map(trr => setDoc(doc(firestore, 'users', user.id, 'trrs', trr.id), trr))
+      );
+
+      return { seeded: true };
+    } catch (error: any) {
+      console.error('Failed to seed starter data:', error);
+      return { seeded: false, error: error.message || 'Failed to seed starter data' };
+    }
   }
 
   // Metrics and Analytics
@@ -660,7 +985,7 @@ export const dcAPIClient = new DCAPIClient();
 
 // Utility functions for common operations
 export const DCOperations = {
-  async initializeCustomerPOV(customerData: Omit<CustomerEngagement, 'id' | 'createdAt' | 'updatedAt'>) {
+  async initializeCustomerPOV(context: UserScopeContext, customerData: Omit<CustomerEngagement, 'id' | 'createdAt' | 'updatedAt'>) {
     const customerResponse = await dcAPIClient.createCustomer(customerData);
     if (!customerResponse.success || !customerResponse.data) {
       throw new Error(customerResponse.error || 'Failed to create customer');
@@ -691,7 +1016,7 @@ export const DCOperations = {
       nextSteps: []
     };
 
-    const povResponse = await dcAPIClient.createPOV(povData);
+    const povResponse = await dcAPIClient.createPOV(context, povData);
     if (!povResponse.success) {
       throw new Error(povResponse.error || 'Failed to create POV');
     }
@@ -702,7 +1027,7 @@ export const DCOperations = {
     };
   },
 
-  async generateTRRSet(customerId: string, povId: string, scenarios: string[]) {
+  async generateTRRSet(context: UserScopeContext, customerId: string, povId: string, scenarios: string[]) {
     const trrPromises = scenarios.map(async (scenario, index) => {
       const trrData: Omit<TRRRecord, 'id' | 'createdAt' | 'updatedAt'> = {
         customerId,
@@ -729,7 +1054,7 @@ export const DCOperations = {
         notes: []
       };
 
-      return dcAPIClient.createTRR(trrData);
+      return dcAPIClient.createTRR(context, trrData);
     });
 
     const results = await Promise.all(trrPromises);

--- a/hosting/lib/dc-context-store.ts
+++ b/hosting/lib/dc-context-store.ts
@@ -14,6 +14,7 @@ export interface UserProfile {
 
 export interface CustomerEngagement {
   id: string;
+  ownerId?: string;
   name: string;
   industry: string;
   size: 'startup' | 'smb' | 'mid-market' | 'enterprise';
@@ -44,6 +45,7 @@ export interface CustomerEngagement {
 
 export interface ActivePOV {
   id: string;
+  ownerId?: string;
   customerId: string;
   name: string;
   status: 'planning' | 'executing' | 'completed' | 'on-hold';
@@ -79,6 +81,7 @@ export interface ActivePOV {
 
 export interface TRRRecord {
   id: string;
+  ownerId?: string;
   customerId: string;
   povId?: string;
   title: string;
@@ -353,163 +356,145 @@ class DCContextStore {
     };
   }
 
-  // Initialize sample data for development/demo
-  initializeSampleData() {
-    // Sample user
-    const sampleUser: UserProfile = {
-      id: 'dc_user_001',
-      name: 'Demo User',
-      email: 'demo@henryreed.ai',
-      role: 'dc',
-      region: 'AMER',
-      specializations: ['Cloud Security', 'XSIAM', 'POV Management'],
-      createdAt: new Date().toISOString(),
-      lastActive: new Date().toISOString()
-    };
-    this.setCurrentUser(sampleUser);
+  }
 
-    // Sample customer engagement
+  // Onboarding starter data generation scoped to authenticated user
+  seedStarterDataForUser(user: UserProfile) {
+    if (!user?.id) {
+      throw new Error('Valid user profile required to seed starter data');
+    }
+
+    const existingRecords = Array.from(this.data.trrRecords.values()).some(record => record.ownerId === user.id);
+    if (existingRecords) {
+      return { seeded: false };
+    }
+
+    const customerId = `cust_${user.id}_starter`;
+    const povId = `pov_${user.id}_starter`;
+
     const sampleCustomer: CustomerEngagement = {
-      id: 'cust_001',
-      name: 'TechCorp Industries',
+      id: customerId,
+      ownerId: user.id,
+      name: 'Starter Engagement',
       industry: 'Technology',
       size: 'enterprise',
       maturityLevel: 'intermediate',
       primaryConcerns: ['Cloud Security', 'Insider Threats', 'Compliance'],
       techStack: ['AWS', 'Kubernetes', 'Splunk', 'ServiceNow'],
       stakeholders: [
-        { name: 'John Smith', role: 'CISO', influence: 'high', technical: true },
-        { name: 'Sarah Johnson', role: 'Security Manager', influence: 'medium', technical: true },
-        { name: 'Mike Davis', role: 'IT Director', influence: 'medium', technical: false }
+        { name: 'Executive Sponsor', role: 'CISO', influence: 'high', technical: true },
+        { name: 'Security Manager', role: 'Security Manager', influence: 'medium', technical: true }
       ],
       timeline: {
-        startDate: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString(),
-        targetDecision: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+        startDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+        targetDecision: new Date(Date.now() + 21 * 24 * 60 * 60 * 1000).toISOString(),
         keyMilestones: [
-          { name: 'Initial Assessment', date: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(), status: 'complete' },
-          { name: 'POV Kickoff', date: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(), status: 'complete' },
-          { name: 'Executive Briefing', date: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(), status: 'pending' }
+          { name: 'Initial Assessment', date: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(), status: 'complete' },
+          { name: 'POV Kickoff', date: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(), status: 'complete' },
+          { name: 'Executive Briefing', date: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(), status: 'pending' }
         ]
       },
       budget: {
-        range: '$500K-$1M',
-        decisionMaker: 'John Smith (CISO)',
-        approvalProcess: 'Executive Committee Review'
+        range: '$250K-$500K',
+        decisionMaker: 'Executive Sponsor',
+        approvalProcess: 'Executive Steering Committee'
       },
       competition: ['CrowdStrike', 'Microsoft Sentinel'],
       notes: [
-        'Strong technical team, looking for advanced automation',
-        'Previous bad experience with legacy SIEM',
-        'High interest in cloud-native solutions'
+        'Starter engagement generated for onboarding',
+        'Customize this record with real customer information'
       ],
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
-    this.addCustomerEngagement(sampleCustomer);
 
-    // Sample POV
     const samplePOV: ActivePOV = {
-      id: 'pov_001',
-      customerId: 'cust_001',
-      name: 'TechCorp XSIAM POV',
-      status: 'executing',
+      id: povId,
+      ownerId: user.id,
+      customerId,
+      name: 'Starter XSIAM POV',
+      status: 'planning',
       scenarios: [
-        { id: 'sc_001', name: 'Cloud Posture Assessment', type: 'cloud-posture', status: 'completed', results: 'Identified 15 misconfigurations', customerFeedback: 'Very impressed with visibility' },
-        { id: 'sc_002', name: 'Insider Threat Detection', type: 'insider-threat', status: 'deployed', results: 'Currently monitoring 500 users' },
-        { id: 'sc_003', name: 'Ransomware Simulation', type: 'ransomware', status: 'planned' }
+        { id: `sc_${user.id}_001`, name: 'Cloud Posture Assessment', type: 'cloud-posture', status: 'planned' },
+        { id: `sc_${user.id}_002`, name: 'Insider Threat Detection', type: 'insider-threat', status: 'planned' }
       ],
       objectives: [
-        'Demonstrate superior detection capabilities',
-        'Show integration with existing AWS infrastructure',
-        'Prove ROI through automation savings'
+        'Demonstrate detection and response capabilities',
+        'Integrate with existing cloud infrastructure'
       ],
       successMetrics: [
-        'Detect 90%+ of simulated attacks',
-        'Reduce MTTD by 50%',
-        'Automate 80% of tier-1 responses'
+        'Detect 90% of simulated attacks',
+        'Automate 70% of tier-1 responses'
       ],
       timeline: {
-        planned: '6 weeks',
-        actual: '4 weeks completed',
+        planned: new Date().toISOString(),
+        actual: undefined,
         milestones: [
-          { name: 'Environment Setup', planned: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(), actual: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString() },
-          { name: 'Scenario Execution', planned: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString() },
-          { name: 'Results Presentation', planned: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString() }
+          { name: 'Environment Setup', planned: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString() },
+          { name: 'Scenario Execution', planned: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString() }
         ]
       },
       resources: {
-        dcHours: 40,
-        seHours: 20,
-        infrastructure: ['AWS Test Environment', 'XSIAM Tenant', 'Sample Data Sets']
+        dcHours: 32,
+        seHours: 16,
+        infrastructure: ['XSIAM Tenant', 'Sample Data Sets']
       },
       outcomes: {
-        technicalWins: ['Faster detection than current solution', 'Better integration capabilities'],
-        businessImpact: ['Projected 60% reduction in analyst time', '$200K annual savings'],
-        lessonsLearned: ['Customer values automation over alerts', 'Integration complexity is key concern']
+        technicalWins: [],
+        businessImpact: [],
+        lessonsLearned: []
       },
-      nextSteps: ['Complete ransomware scenario', 'Prepare executive presentation', 'Draft technical proposal'],
+      nextSteps: ['Add customer-specific milestones', 'Document technical requirements'],
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
-    this.addActivePOV(samplePOV);
 
-    // Sample TRRs
     const sampleTRRs: TRRRecord[] = [
       {
-        id: 'trr_001',
-        customerId: 'cust_001',
-        povId: 'pov_001',
-        title: 'AWS CloudTrail Integration',
+        id: `trr_${user.id}_001`,
+        ownerId: user.id,
+        customerId,
+        povId,
+        title: 'CloudTrail Integration Validation',
         category: 'integration',
         priority: 'high',
-        status: 'validated',
-        description: 'Validate XSIAM can ingest and parse AWS CloudTrail logs',
-        acceptanceCriteria: ['Logs ingested within 5 minutes', 'All standard fields parsed correctly', 'Custom queries work'],
-        validationMethod: 'Live demonstration with customer data',
-        validationEvidence: ['Screenshots of parsed logs', 'Query results', 'Performance metrics'],
-        assignedTo: 'Demo User',
-        reviewers: ['John Smith', 'Sarah Johnson'],
+        status: 'draft',
+        description: 'Validate ingestion and parsing of AWS CloudTrail logs into XSIAM.',
+        acceptanceCriteria: [
+          'Logs ingested within 5 minutes',
+          'Standard fields parsed correctly',
+          'Custom queries execute successfully'
+        ],
+        validationMethod: 'Demonstration with sample datasets',
+        validationEvidence: [],
+        assignedTo: user.name,
+        reviewers: ['Security Manager'],
         timeline: {
-          created: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
-          targetValidation: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
-          actualValidation: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString()
+          created: new Date().toISOString(),
+          targetValidation: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString(),
+          actualValidation: undefined
         },
-        dependencies: ['AWS test account', 'CloudTrail configuration'],
+        dependencies: ['AWS account access', 'CloudTrail configuration'],
         riskLevel: 'medium',
-        businessImpact: 'Critical for cloud visibility requirements',
-        customerStakeholder: 'Mike Davis',
-        notes: ['Customer very satisfied with ingestion speed', 'Requested additional custom fields'],
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      },
-      {
-        id: 'trr_002',
-        customerId: 'cust_001',
-        povId: 'pov_001',
-        title: 'ServiceNow Integration',
-        category: 'integration',
-        priority: 'medium',
-        status: 'in-review',
-        description: 'Validate bi-directional integration with ServiceNow for incident management',
-        acceptanceCriteria: ['Incidents created automatically', 'Status updates sync back', 'Custom fields mapped'],
-        validationMethod: 'End-to-end workflow testing',
-        assignedTo: 'Demo User',
-        reviewers: ['Sarah Johnson'],
-        timeline: {
-          created: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
-          targetValidation: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString()
-        },
-        dependencies: ['ServiceNow dev instance', 'API credentials'],
-        riskLevel: 'low',
-        businessImpact: 'Important for operational workflow',
-        customerStakeholder: 'Sarah Johnson',
-        notes: ['Waiting for dev instance access', 'Customer excited about automation potential'],
+        businessImpact: 'Critical for establishing cloud visibility',
+        customerStakeholder: 'Executive Sponsor',
+        notes: ['Starter TRR created for onboarding'],
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString()
       }
     ];
-    
+
+    this.setCurrentUser(user);
+    this.addCustomerEngagement(sampleCustomer);
+    this.addActivePOV(samplePOV);
     sampleTRRs.forEach(trr => this.addTRRRecord(trr));
+
+    return {
+      seeded: true,
+      customer: sampleCustomer,
+      pov: samplePOV,
+      trrs: sampleTRRs
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- migrate TRR and POV API calls to Firestore collections keyed by authenticated users and add a starter-data seeding helper
- update TRR and POV management components to load, create, and update records using the active user context and show onboarding messaging
- ensure other UI surfaces trigger the new onboarding workflow instead of the removed global sample data initializer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7f6495d708326a5b7a8eb86ddd616