### PR TITLE
Refresh Cortex palette integration

### DIFF
--- a/hosting/STYLING_GUIDE.md
+++ b/hosting/STYLING_GUIDE.md
@@ -6,19 +6,21 @@ The Cortex Domain Consultant Portal uses a comprehensive styling system built on
 ## Color System
 
 ### Primary Cortex Colors
-- `cortex-orange`: #FF6900 (Primary accent)
-- `cortex-orange-light`: #FF8533 (Hover states)
-- `cortex-orange-dark`: #E55A00 (Active states)
-- `cortex-green`: #00CC66 (Success states)
-- `cortex-green-light`: #33D580 (Success hover)
-- `cortex-green-dark`: #00B359 (Success active)
+- `cortex-primary`: #00CC66 (Cortex primary green)
+- `cortex-primary-light`: #36E795 (Hover states)
+- `cortex-primary-dark`: #009C4E (Active states)
+- `cortex-teal`: #15BDB2 (Teal accent)
+- `cortex-blue`: #00C0E8 (Neon blue accent)
+- `cortex-cyan`: #00D6FF (Electric cyan highlight)
+- `cortex-purple`: #827DFF (Signal purple accent)
+- `cortex-accent`: #78DCFF (Soft glow overlay)
 
 ### Background Hierarchy
-- `cortex-bg-primary`: #000000 (Main background)
-- `cortex-bg-secondary`: #0D1117 (Content areas)
-- `cortex-bg-tertiary`: #161B22 (Cards/modals)
-- `cortex-bg-quaternary`: #21262D (Elevated elements)
-- `cortex-bg-hover`: #30363D (Interactive states)
+- `cortex-bg-primary`: #050C11 (Main background)
+- `cortex-bg-secondary`: #081118 (Content areas)
+- `cortex-bg-tertiary`: #0E1A22 (Cards & modals)
+- `cortex-bg-quaternary`: #13232D (Elevated elements)
+- `cortex-bg-hover`: #1A303C (Interactive states)
 
 ### Text Hierarchy
 - `cortex-text-primary`: #F0F6FC (Main text)
@@ -27,10 +29,10 @@ The Cortex Domain Consultant Portal uses a comprehensive styling system built on
 - `cortex-text-disabled`: #6E7681 (Disabled states)
 
 ### Status Colors
-- `cortex-success`: #00CC66 (Success states)
-- `cortex-error`: #F85149 (Error states)
-- `cortex-warning`: #F1C40F (Warning states)
-- `cortex-info`: #58A6FF (Information states)
+- `status-success`: #00CC8C (Success states)
+- `status-error`: #EF5350 (Error states)
+- `status-warning`: #FFAB26 (Warning states)
+- `status-info`: #20C4FF (Information states)
 
 ## Component Classes
 
@@ -53,10 +55,10 @@ The Cortex Domain Consultant Portal uses a comprehensive styling system built on
 - `.cortex-glow-pulse` - Pulsing glow effect
 
 ### Button Variants
-- Primary: `bg-gradient-to-r from-cortex-orange to-cortex-green`
-- Secondary: `bg-cortex-bg-quaternary hover:bg-cortex-bg-hover`
-- Success: `bg-cortex-success hover:bg-cortex-success-light`
-- Error: `bg-cortex-error hover:bg-cortex-error-light`
+- Primary: `bg-gradient-to-r from-cortex-primary to-cortex-blue`
+- Secondary: `bg-cortex-bg-quaternary/80 hover:bg-cortex-bg-hover border border-cortex-border`
+- Success: `bg-gradient-to-r from-cortex-primary to-cortex-teal`
+- Error: `bg-status-error hover:bg-status-error/90`
 
 ## Usage Examples
 
@@ -64,7 +66,7 @@ The Cortex Domain Consultant Portal uses a comprehensive styling system built on
 ```jsx
 <div className="bg-cortex-bg-tertiary/80 backdrop-blur-xl border border-cortex-border-secondary rounded-2xl">
   <input className="bg-cortex-bg-primary/50 border border-cortex-border-muted text-cortex-text-primary" />
-  <button className="bg-gradient-to-r from-cortex-orange to-cortex-green text-cortex-text-primary">
+  <button className="bg-gradient-to-r from-cortex-primary to-cortex-blue text-white">
     Submit
   </button>
 </div>
@@ -73,23 +75,23 @@ The Cortex Domain Consultant Portal uses a comprehensive styling system built on
 ### Status Indicators
 ```jsx
 <div className="flex items-center space-x-2">
-  <div className="w-2 h-2 bg-cortex-success rounded-full animate-pulse"></div>
+  <div className="w-2 h-2 bg-status-success rounded-full animate-pulse"></div>
   <span className="text-cortex-text-muted">System Online</span>
 </div>
 ```
 
 ### Loading States
 ```jsx
-<div className="animate-spin border-4 border-cortex-border-muted border-t-cortex-orange"></div>
+<div className="animate-spin border-4 border-cortex-border-muted border-t-cortex-primary"></div>
 ```
 
 ## CSS Custom Properties
 All colors are also available as CSS custom properties:
-- `--cortex-orange`
-- `--cortex-green`
-- `--cortex-bg-primary`
-- `--cortex-text-primary`
-- etc.
+- `--cortex-primary`, `--cortex-primary-light`, `--cortex-primary-dark`
+- `--cortex-teal`, `--cortex-blue`, `--cortex-cyan`, `--cortex-purple`
+- `--cortex-border`, `--cortex-border-secondary`, `--cortex-border-muted`
+- `--cortex-bg-primary`, `--cortex-bg-secondary`, `--cortex-bg-tertiary`, `--cortex-bg-hover`
+- `--cortex-text-primary`, `--cortex-text-secondary`, `--cortex-text-muted`, `--cortex-text-disabled`
 
 ## Development Commands
 

--- a/hosting/app/globals.css
+++ b/hosting/app/globals.css
@@ -8,75 +8,53 @@
 /* CSS Custom Properties for Cortex Theme */
 @layer base {
   :root {
-    /* LEGACY Cortex Color System (preserved for compatibility) */
-    --cortex-orange: #FF6900;
-    --cortex-orange-light: #FF8533;
-    --cortex-orange-dark: #E55A00;
-    --cortex-green: #00CC66;
-    --cortex-green-light: #33D580;
-    --cortex-green-dark: #00B359;
-    
-    /* MODERN Cortex XSIAM Brand Colors (Official) */
-    /* RGB space for opacity utilities */
-    --cortex-primary: 0 204 102;     /* #00CC66 - Cortex green */
-    --cortex-primary-light: 51 213 128; /* #33D580 - Light green */
-    --cortex-primary-dark: 0 179 89;    /* #00B359 - Dark green */
-    --cortex-accent: 250 88 45;      /* #FA582D - PANW orange accent */
-    --cortex-blue: 0 192 232;        /* #00C0E8 - Interactive blue */
-    --cortex-gray: 107 114 128;      /* #6B7280 - UI gray */
-    --cortex-dark: 20 20 20;         /* #141414 */
-    
-    /* Surface Tokens (Dark Theme Optimized) */
-    --cortex-canvas: 0 0 0;          /* #000000 - App background */
-    --cortex-surface: 20 20 20;      /* #141414 - Card/panel background */
-    --cortex-elevated: 26 26 26;     /* #1A1A1A - Elevated surfaces */
-    --cortex-border: 48 48 48;       /* #303030 - Default borders */
-    
-  /* Text Tokens (Enhanced Visibility & Contrast) */
-    --cortex-text-primary: 255 255 255;   /* #FFFFFF - Headings (bright white) */
-    --cortex-text-secondary: 245 245 245; /* #F5F5F5 - Body text (off-white) */
-    --cortex-text-muted: 200 200 200;     /* #C8C8C8 - Meta text (light gray) */
-    
-    /* Status Colors (WCAG AA Compliant) */
-    --status-success: 0 204 102;     /* #00CC66 - Cortex green */
-    --status-warning: 245 158 11;    /* #F59E0B */
-    --status-error: 239 68 68;       /* #EF4444 */
-    --status-info: 0 192 232;        /* #00C0E8 */
-    
+    /* Cortex Brand Palette (2025 refresh) */
+    --cortex-primary: 0 204 102;        /* #00CC66 */
+    --cortex-primary-light: 54 231 149; /* #36E795 */
+    --cortex-primary-dark: 0 156 78;    /* #009C4E */
+    --cortex-green: 0 204 102;          /* Alias for legacy usage */
+    --cortex-teal: 21 189 178;          /* #15BDB2 */
+    --cortex-blue: 0 192 232;           /* #00C0E8 */
+    --cortex-cyan: 0 214 255;           /* #00D6FF */
+    --cortex-purple: 130 125 255;       /* #827DFF */
+    --cortex-accent: 120 220 255;       /* Soft cyan glow */
+    --cortex-dark: 8 17 24;             /* #081118 */
+
+    /* Surface Tokens */
+    --cortex-canvas: 6 12 16;           /* #060C10 */
+    --cortex-surface: 10 20 27;         /* #0A141B */
+    --cortex-elevated: 14 26 34;        /* #0E1A22 */
+    --cortex-border: 28 44 54;          /* #1C2C36 */
+    --cortex-border-strong: 36 56 68;   /* #243844 */
+    --cortex-border-secondary: 46 70 82;/* #2E4652 */
+    --cortex-border-muted: 64 88 100;   /* #405864 */
+
+    /* Text tokens */
+    --cortex-text-primary: 224 244 239;   /* #E0F4EF */
+    --cortex-text-secondary: 188 214 207; /* #BCD6CF */
+    --cortex-text-muted: 148 173 168;     /* #94ADA8 */
+    --cortex-text-disabled: 110 130 126;  /* #6E827E */
+
+    /* Background aliases (legacy token compatibility) */
+    --cortex-bg-primary: #050C11;
+    --cortex-bg-secondary: #081118;
+    --cortex-bg-tertiary: #0E1A22;
+    --cortex-bg-quaternary: #13232D;
+    --cortex-bg-hover: #1A303C;
+
+    /* Status Colors */
+    --status-success: 0 204 140;       /* Slightly brighter success */
+    --status-warning: 255 171 38;      /* Vibrant amber */
+    --status-error: 239 83 80;         /* Alert red */
+    --status-info: 32 196 255;         /* Electric blue */
+
     /* Focus & Ring Colors */
-    --ring-brand: 0 204 102;         /* Cortex green for focus */
-    --ring-focus: 0 204 102;         /* Cortex green for outline */
-    
-    /* Glass & Effects */
-    --glass-tint: 255 255 255;       /* White tint for glassmorphism */
-    
-    /* LEGACY Background Hierarchy (preserved) */
-    --cortex-bg-primary: #000000;
-    --cortex-bg-secondary: #0D1117;
-    --cortex-bg-tertiary: #161B22;
-    --cortex-bg-quaternary: #21262D;
-    --cortex-bg-hover: #30363D;
-    
-    /* LEGACY Text Hierarchy (enhanced visibility) */
-    --cortex-text-primary: #FFFFFF;
-    --cortex-text-secondary: #E6E6E6;
-    --cortex-text-muted: #BEBEBE;
-    --cortex-text-disabled: #9B9B9B;
-    
-    /* LEGACY Border System (preserved) */
-    --cortex-border-primary: #FF6900;
-    --cortex-border-secondary: #30363D;
-    --cortex-border-muted: #21262D;
-    
-    /* LEGACY Status Colors (preserved) */
-    --cortex-success: #00CC66;
-    --cortex-error: #F85149;
-    --cortex-warning: #F1C40F;
-    --cortex-info: #58A6FF;
-    
-    /* LEGACY Shadows (preserved) */
-    --cortex-shadow-glow: 0 0 20px rgba(255, 105, 0, 0.4);
-    --cortex-shadow-terminal: 0 0 50px rgba(0, 204, 102, 0.3);
+    --ring-brand: 0 204 140;
+    --ring-focus: 0 192 232;
+
+    /* Glass & Glow */
+    --glass-tint: 255 255 255;
+    --cortex-shadow-terminal: 0 0 45px rgba(0, 204, 140, 0.25);
   }
 }
 
@@ -88,8 +66,8 @@ html {
 }
 
 body {
-  background-color: #000000;
-  color: #F5F5F5; /* Slightly off-white for better eye comfort */
+  background-color: #050C11;
+  color: rgb(var(--cortex-text-secondary));
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   margin: 0;
   padding: 0;
@@ -103,77 +81,80 @@ body {
 
 /* Button styles */
 .btn-primary {
-  background-color: #e97444;
-  color: #ffffff;
+  background-image: linear-gradient(135deg, rgb(var(--cortex-primary)) 0%, rgb(var(--cortex-blue)) 100%);
+  color: rgb(var(--cortex-text-primary));
   font-weight: 600;
   padding: 0.75rem 1rem;
-  border-radius: 0.5rem;
-  border: 1px solid #e97444;
-  transition: all 200ms;
+  border-radius: 0.75rem;
+  border: 1px solid rgb(var(--cortex-primary) / 0.5);
+  box-shadow: 0 10px 30px rgba(0, 192, 232, 0.2);
+  transition: transform 200ms ease, box-shadow 200ms ease, filter 200ms ease;
   cursor: pointer;
 }
 
 .btn-primary:hover {
-  background-color: #f19968;
-  border-color: #f19968;
-  box-shadow: 0 0 20px rgba(233, 116, 68, 0.4);
+  filter: brightness(1.05);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 40px rgba(0, 192, 232, 0.28);
 }
 
 .btn-primary:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(233, 116, 68, 0.5);
+  box-shadow: 0 0 0 3px rgba(0, 192, 232, 0.3);
 }
 
 /* Input styles */
 input {
   width: 100%;
   padding: 0.75rem 1rem;
-  background-color: #161B22;
-  border: 1px solid #30363D;
+  background-color: rgb(var(--cortex-surface) / 0.85);
+  border: 1px solid rgb(var(--cortex-border) / 0.8);
   border-radius: 0.5rem;
-  color: #F5F5F5; /* Match body text color */
+  color: rgb(var(--cortex-text-primary));
   font-family: 'JetBrains Mono', Consolas, Monaco, 'Courier New', monospace;
   font-size: 0.875rem; /* For better readability */
 }
 
 input::placeholder {
-  color: #999999; /* Darker placeholder for better readability */
+  color: rgb(var(--cortex-text-muted) / 0.65);
 }
 
 input:focus {
   outline: none;
-  border-color: #e97444;
-  box-shadow: 0 0 0 2px rgba(233, 116, 68, 0.2);
+  border-color: rgb(var(--cortex-primary) / 0.6);
+  box-shadow: 0 0 0 2px rgb(var(--cortex-blue) / 0.25);
 }
 
 /* Glass card effect */
 .glass-card {
-  background: rgba(33, 38, 45, 0.9);
+  background: rgb(var(--cortex-surface) / 0.85);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-  border: 1px solid rgba(233, 116, 68, 0.2);
-  border-radius: 0.5rem;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  transition: all 500ms;
+  border: 1px solid rgb(var(--cortex-border) / 0.45);
+  border-radius: 0.75rem;
+  box-shadow: 0 16px 48px rgba(5, 12, 17, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition: border-color 300ms ease, box-shadow 300ms ease, transform 300ms ease;
 }
 
 .glass-card:hover {
-  border-color: rgba(233, 116, 68, 0.4);
+  border-color: rgb(var(--cortex-blue) / 0.5);
+  box-shadow: 0 20px 60px rgba(0, 192, 232, 0.18);
+  transform: translateY(-2px);
 }
 
 /* Status messages */
 .status-error {
-  color: #F85149;
-  background-color: #2D0F0F;
-  border: 1px solid #F85149;
+  color: rgb(var(--status-error));
+  background-color: rgb(var(--status-error) / 0.12);
+  border: 1px solid rgb(var(--status-error) / 0.4);
   padding: 0.75rem;
-  border-radius: 0.5rem;
+  border-radius: 0.75rem;
 }
 
 /* Loading spinner - Enhanced */
 .spinner {
-  border: 3px solid var(--cortex-border-muted);
-  border-top: 3px solid var(--cortex-orange);
+  border: 3px solid rgb(var(--cortex-border) / 0.35);
+  border-top: 3px solid rgb(var(--cortex-primary));
   border-radius: 50%;
   width: 20px;
   height: 20px;
@@ -248,11 +229,13 @@ input:focus {
 
 @keyframes glowPulse {
   0%, 100% {
-    box-shadow: 0 0 20px var(--cortex-orange), 0 0 40px var(--cortex-orange);
-    opacity: 0.8;
+    box-shadow: 0 0 22px rgb(var(--cortex-primary) / 0.55),
+      0 0 48px rgb(var(--cortex-cyan) / 0.4);
+    opacity: 0.9;
   }
   50% {
-    box-shadow: 0 0 30px var(--cortex-orange), 0 0 60px var(--cortex-orange);
+    box-shadow: 0 0 36px rgb(var(--cortex-blue) / 0.65),
+      0 0 80px rgb(var(--cortex-purple) / 0.45);
     opacity: 1;
   }
 }
@@ -295,13 +278,13 @@ input:focus {
 
 /* Default text selection for better readability */
 *::selection {
-  background-color: #FF6900;
-  color: #000000;
+  background-color: rgba(0, 192, 232, 0.35);
+  color: #071018;
 }
 
 *::-moz-selection {
-  background-color: #FF6900;
-  color: #000000;
+  background-color: rgba(0, 192, 232, 0.35);
+  color: #071018;
 }
 
 /* Ensure text is properly styled in all contexts */
@@ -310,18 +293,18 @@ input:focus {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  color: #FFFFFF; /* Bright white for headings */
+  color: rgb(var(--cortex-text-primary));
   font-weight: 600;
 }
 
 p, span, div {
-  color: #F5F5F5; /* Consistent body text */
+  color: rgb(var(--cortex-text-secondary));
 }
 
 /* PANW Cortex Terminal Scrollbar */
 .terminal-scrollbar {
   scrollbar-width: thin;
-  scrollbar-color: #FF6900 #161B22;
+  scrollbar-color: rgba(0, 192, 232, 0.7) rgba(10, 20, 27, 0.8);
 }
 
 .terminal-scrollbar::-webkit-scrollbar {
@@ -329,138 +312,138 @@ p, span, div {
 }
 
 .terminal-scrollbar::-webkit-scrollbar-track {
-  background: #161B22;
+  background: rgba(10, 20, 27, 0.85);
   border-radius: 4px;
 }
 
 .terminal-scrollbar::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, #FF6900 0%, #E55A00 100%);
+  background: linear-gradient(180deg, rgba(0, 192, 232, 0.9) 0%, rgba(0, 204, 140, 0.9) 100%);
   border-radius: 4px;
-  border: 1px solid #21262D;
+  border: 1px solid rgba(28, 44, 54, 0.8);
 }
 
 .terminal-scrollbar::-webkit-scrollbar-thumb:hover {
-  background: linear-gradient(180deg, #FF8533 0%, #FF6900 100%);
+  background: linear-gradient(180deg, rgba(0, 192, 232, 1) 0%, rgba(0, 204, 140, 1) 100%);
 }
 
-/* PANW Cortex Text Selection */
+/* Cortex Text Selection */
 ::selection {
-  background-color: #FF6900;
-  color: #000000;
+  background-color: rgba(0, 192, 232, 0.35);
+  color: #071018;
 }
 
 ::-moz-selection {
-  background-color: #FF6900;
-  color: #000000;
+  background-color: rgba(0, 192, 232, 0.35);
+  color: #071018;
 }
 
-/* PANW Cortex Component Styles - Pure CSS */
-/* Terminal prompt with Cortex orange */
+/* Cortex Component Styles - Pure CSS */
+/* Terminal prompt with Cortex neon accent */
 .cortex-prompt {
-  color: #FF6900;
+  color: #00C0E8;
   font-family: 'JetBrains Mono', Consolas, Monaco, 'Courier New', monospace;
 }
 
 /* PANW Cortex button variants */
 .btn-cortex-secondary {
-  background-color: #21262D;
-  color: #FFFFFF;
+  background-color: rgba(var(--cortex-surface), 0.9);
+  color: rgb(var(--cortex-text-primary));
   font-weight: 600;
   padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
-  border: 1px solid #30363D;
-  transition: all 200ms;
+  border-radius: 0.75rem;
+  border: 1px solid rgb(var(--cortex-border) / 0.6);
+  transition: all 200ms ease;
 }
 
 .btn-cortex-secondary:hover {
-  background-color: #30363D;
-  border-color: #00CC66;
+  background-color: rgba(var(--cortex-elevated), 0.95);
+  border-color: rgb(var(--cortex-primary));
 }
 
 .btn-cortex-secondary:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(0, 204, 102, 0.5);
+  box-shadow: 0 0 0 2px rgba(0, 192, 232, 0.35);
 }
 
 .btn-cortex-outline {
   background-color: transparent;
-  color: #00CC66;
+  color: rgb(var(--cortex-primary));
   font-weight: 600;
   padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
-  border: 1px solid #00CC66;
-  transition: all 200ms;
+  border-radius: 0.75rem;
+  border: 1px solid rgb(var(--cortex-primary));
+  transition: all 200ms ease;
 }
 
 .btn-cortex-outline:hover {
-  background-color: #00CC66;
-  color: #000000;
+  background-image: linear-gradient(135deg, rgb(var(--cortex-primary)) 0%, rgb(var(--cortex-blue)) 100%);
+  color: rgb(var(--cortex-dark));
 }
 
 .btn-cortex-outline:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(0, 204, 102, 0.5);
+  box-shadow: 0 0 0 2px rgba(0, 192, 232, 0.35);
 }
 
 .btn-cortex-success {
-  background-color: #00CC66;
-  color: #000000;
+  background-image: linear-gradient(135deg, rgb(var(--cortex-primary)) 0%, rgb(var(--cortex-teal)) 100%);
+  color: rgb(var(--cortex-dark));
   font-weight: 600;
   padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
-  border: 1px solid #00CC66;
-  transition: all 200ms;
+  border-radius: 0.75rem;
+  border: 1px solid rgb(var(--cortex-primary));
+  transition: all 200ms ease;
 }
 
 .btn-cortex-success:hover {
-  background-color: #33D580;
-  border-color: #33D580;
+  filter: brightness(1.05);
+  border-color: rgb(var(--cortex-teal));
 }
 
 .btn-cortex-success:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(0, 204, 102, 0.5);
+  box-shadow: 0 0 0 2px rgba(0, 204, 140, 0.35);
 }
 
 /* PANW Cortex card styles */
 .cortex-card {
-  background-color: #161B22;
-  border: 1px solid #30363D;
-  border-radius: 0.5rem;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  backdrop-filter: blur(4px);
-  transition: all 200ms;
+  background-color: rgb(var(--cortex-surface) / 0.95);
+  border: 1px solid rgb(var(--cortex-border) / 0.45);
+  border-radius: 0.75rem;
+  box-shadow: 0 16px 40px rgba(5, 12, 17, 0.45);
+  backdrop-filter: blur(8px);
+  transition: all 200ms ease;
 }
 
 .cortex-card:hover {
-  border-color: #00CC66;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  border-color: rgb(var(--cortex-primary));
+  box-shadow: 0 22px 50px rgba(0, 192, 232, 0.18);
 }
 
 .cortex-card-elevated {
-  background-color: #21262D;
-  border: 1px solid #30363D;
-  border-radius: 0.5rem;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-  backdrop-filter: blur(4px);
-  transition: all 200ms;
+  background-color: rgb(var(--cortex-elevated) / 0.95);
+  border: 1px solid rgb(var(--cortex-border) / 0.4);
+  border-radius: 1rem;
+  box-shadow: 0 28px 60px rgba(7, 16, 24, 0.55);
+  backdrop-filter: blur(12px);
+  transition: all 200ms ease;
 }
 
 .cortex-card-elevated:hover {
-  border-color: #00CC66;
+  border-color: rgb(var(--cortex-blue));
 }
 
 .cortex-card-primary {
-  background-color: #21262D;
-  border: 1px solid #00CC66;
-  border-radius: 0.5rem;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-  backdrop-filter: blur(4px);
-  transition: all 200ms;
+  background-image: linear-gradient(135deg, rgba(0, 192, 232, 0.15) 0%, rgba(0, 204, 140, 0.15) 100%);
+  border: 1px solid rgb(var(--cortex-primary));
+  border-radius: 1rem;
+  box-shadow: 0 28px 60px rgba(0, 192, 232, 0.18);
+  backdrop-filter: blur(12px);
+  transition: all 200ms ease;
 }
 
 .cortex-card-primary:hover {
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 32px 72px rgba(0, 204, 140, 0.22);
 }
 
 /* Status indicators - Updated to use actual values */
@@ -732,14 +715,14 @@ input:focus, textarea:focus, select:focus {
 
 /* Advanced Gradient Backgrounds */
 .gradient-mesh {
-  background: 
+  background:
     radial-gradient(circle at 20% 80%, rgba(0, 204, 102, 0.1) 0%, transparent 50%),
-    radial-gradient(circle at 80% 20%, rgba(255, 105, 0, 0.1) 0%, transparent 50%),
-    radial-gradient(circle at 40% 40%, rgba(88, 166, 255, 0.1) 0%, transparent 50%);
+    radial-gradient(circle at 80% 20%, rgba(0, 192, 232, 0.1) 0%, transparent 50%),
+    radial-gradient(circle at 40% 40%, rgba(120, 220, 255, 0.12) 0%, transparent 50%);
 }
 
 .gradient-border {
-  background: linear-gradient(45deg, #FF6900, #00CC66, #58A6FF);
+  background: linear-gradient(45deg, #00C0E8, #00CC8C, #74F0D4);
   padding: 2px;
   border-radius: 8px;
 }

--- a/hosting/components/CommandAlignmentGuide.tsx
+++ b/hosting/components/CommandAlignmentGuide.tsx
@@ -180,7 +180,7 @@ const CommandAlignmentGuide = () => {
     <div className="bg-black text-white min-h-screen p-6">
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-cortex-green mb-4">🔄 Terminal ↔ GUI Command Alignment</h1>
+          <h1 className="text-3xl font-bold text-cortex-primary mb-4">🔄 Terminal ↔ GUI Command Alignment</h1>
           <p className="text-cortex-text-secondary">
             Consistent user experience across terminal and graphical interfaces
           </p>
@@ -189,27 +189,27 @@ const CommandAlignmentGuide = () => {
         <div className="space-y-8">
           {commandMappings.map((category, categoryIndex) => (
             <div key={categoryIndex} className="cortex-card p-6">
-              <h2 className="text-2xl font-bold text-cortex-green mb-6">{category.category}</h2>
+              <h2 className="text-2xl font-bold text-cortex-primary mb-6">{category.category}</h2>
               
               <div className="space-y-4">
                 {category.commands.map((mapping, commandIndex) => (
-                  <div key={commandIndex} className="grid grid-cols-1 lg:grid-cols-3 gap-4 p-4 bg-cortex-bg-quaternary rounded border border-cortex-border-muted">
+                  <div key={commandIndex} className="grid grid-cols-1 lg:grid-cols-3 gap-4 p-4 bg-cortex-bg-quaternary rounded border border-cortex-border/30">
                     <div className="space-y-2">
-                      <div className="text-sm font-bold text-cortex-text-accent">Terminal Command</div>
-                      <div className="font-mono text-cortex-green bg-black p-2 rounded text-sm">
+                      <div className="text-sm font-bold text-cortex-accent">Terminal Command</div>
+                      <div className="font-mono text-cortex-primary bg-black p-2 rounded text-sm">
                         {mapping.terminal}
                       </div>
                     </div>
                     
                     <div className="space-y-2">
-                      <div className="text-sm font-bold text-cortex-text-accent">GUI Action</div>
-                      <div className="text-cortex-info bg-cortex-info-bg p-2 rounded text-sm">
+                      <div className="text-sm font-bold text-cortex-accent">GUI Action</div>
+                      <div className="text-status-info bg-status-info-bg p-2 rounded text-sm">
                         {mapping.gui}
                       </div>
                     </div>
                     
                     <div className="space-y-2">
-                      <div className="text-sm font-bold text-cortex-text-accent">Description</div>
+                      <div className="text-sm font-bold text-cortex-accent">Description</div>
                       <div className="text-cortex-text-secondary text-sm">
                         {mapping.description}
                       </div>
@@ -222,47 +222,47 @@ const CommandAlignmentGuide = () => {
         </div>
 
         <div className="mt-12 cortex-card p-6">
-          <h2 className="text-2xl font-bold text-cortex-green mb-4">🎯 Design Principles</h2>
+          <h2 className="text-2xl font-bold text-cortex-primary mb-4">🎯 Design Principles</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
-              <h3 className="text-lg font-bold text-cortex-green-light mb-3">Consistency Goals</h3>
+              <h3 className="text-lg font-bold text-cortex-primary-light mb-3">Consistency Goals</h3>
               <ul className="space-y-2 text-cortex-text-secondary">
                 <li className="flex items-start space-x-2">
-                  <span className="text-cortex-success mt-0.5">✓</span>
+                  <span className="text-status-success mt-0.5">✓</span>
                   <span>Same commands trigger identical backend operations</span>
                 </li>
                 <li className="flex items-start space-x-2">
-                  <span className="text-cortex-success mt-0.5">✓</span>
+                  <span className="text-status-success mt-0.5">✓</span>
                   <span>Buttons are ordered to match terminal command flow</span>
                 </li>
                 <li className="flex items-start space-x-2">
-                  <span className="text-cortex-success mt-0.5">✓</span>
+                  <span className="text-status-success mt-0.5">✓</span>
                   <span>GUI buttons execute exact terminal commands</span>
                 </li>
                 <li className="flex items-start space-x-2">
-                  <span className="text-cortex-success mt-0.5">✓</span>
+                  <span className="text-status-success mt-0.5">✓</span>
                   <span>Same user workflows across both interfaces</span>
                 </li>
               </ul>
             </div>
             
             <div>
-              <h3 className="text-lg font-bold text-cortex-green-light mb-3">User Benefits</h3>
+              <h3 className="text-lg font-bold text-cortex-primary-light mb-3">User Benefits</h3>
               <ul className="space-y-2 text-cortex-text-secondary">
                 <li className="flex items-start space-x-2">
-                  <span className="text-cortex-info mt-0.5">💡</span>
+                  <span className="text-status-info mt-0.5">💡</span>
                   <span>Learn once, use everywhere approach</span>
                 </li>
                 <li className="flex items-start space-x-2">
-                  <span className="text-cortex-info mt-0.5">💡</span>
+                  <span className="text-status-info mt-0.5">💡</span>
                   <span>Seamless switching between interfaces</span>
                 </li>
                 <li className="flex items-start space-x-2">
-                  <span className="text-cortex-info mt-0.5">💡</span>
+                  <span className="text-status-info mt-0.5">💡</span>
                   <span>Consistent muscle memory and workflows</span>
                 </li>
                 <li className="flex items-start space-x-2">
-                  <span className="text-cortex-info mt-0.5">💡</span>
+                  <span className="text-status-info mt-0.5">💡</span>
                   <span>Enhanced productivity and reduced learning curve</span>
                 </li>
               </ul>

--- a/hosting/components/ContentAnalytics.tsx
+++ b/hosting/components/ContentAnalytics.tsx
@@ -27,21 +27,21 @@ const ContentAnalytics: React.FC<ContentAnalyticsProps> = ({ items, className = 
       {/* Key Metrics */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <div className="cortex-card p-6 text-center">
-          <div className="text-3xl font-bold text-cortex-green mb-2">{analytics.totalItems}</div>
+          <div className="text-3xl font-bold text-cortex-primary mb-2">{analytics.totalItems}</div>
           <div className="text-sm text-cortex-text-secondary">Total Items</div>
         </div>
         <div className="cortex-card p-6 text-center">
-          <div className="text-3xl font-bold text-cortex-info mb-2">
+          <div className="text-3xl font-bold text-status-info mb-2">
             {Math.round(analytics.avgRating * 10) / 10}
           </div>
           <div className="text-sm text-cortex-text-secondary">Avg Rating</div>
         </div>
         <div className="cortex-card p-6 text-center">
-          <div className="text-3xl font-bold text-cortex-warning mb-2">{analytics.totalUsage}</div>
+          <div className="text-3xl font-bold text-status-warning mb-2">{analytics.totalUsage}</div>
           <div className="text-sm text-cortex-text-secondary">Total Usage</div>
         </div>
         <div className="cortex-card p-6 text-center">
-          <div className="text-3xl font-bold text-cortex-text-accent mb-2">
+          <div className="text-3xl font-bold text-cortex-accent mb-2">
             {Object.keys(analytics.categoryCounts).length}
           </div>
           <div className="text-sm text-cortex-text-secondary">Categories</div>
@@ -63,7 +63,7 @@ const ContentAnalytics: React.FC<ContentAnalyticsProps> = ({ items, className = 
                   </div>
                   <div className="flex-1 bg-cortex-bg-tertiary rounded-full h-3">
                     <div
-                      className="bg-cortex-warning h-3 rounded-full transition-all duration-300"
+                      className="bg-status-warning h-3 rounded-full transition-all duration-300"
                       style={{ width: `${percentage}%` }}
                     ></div>
                   </div>
@@ -83,10 +83,10 @@ const ContentAnalytics: React.FC<ContentAnalyticsProps> = ({ items, className = 
           {Object.entries(analytics.topTags).map(([tag, count]) => (
             <div
               key={tag}
-              className="flex items-center space-x-2 bg-cortex-info/10 text-cortex-info px-3 py-2 rounded-full border border-cortex-info/30"
+              className="flex items-center space-x-2 bg-status-info/10 text-status-info px-3 py-2 rounded-full border border-status-info/30"
             >
               <span className="font-medium">{tag}</span>
-              <span className="bg-cortex-info/20 text-cortex-info text-xs px-2 py-1 rounded-full">
+              <span className="bg-status-info/20 text-status-info text-xs px-2 py-1 rounded-full">
                 {count}
               </span>
             </div>
@@ -127,7 +127,7 @@ const ContentAnalytics: React.FC<ContentAnalyticsProps> = ({ items, className = 
                 </div>
                 <div className="bg-cortex-bg-tertiary rounded-full h-2">
                   <div
-                    className="bg-cortex-green h-2 rounded-full transition-all duration-300"
+                    className="bg-cortex-primary h-2 rounded-full transition-all duration-300"
                     style={{ width: `${percentage}%` }}
                   ></div>
                 </div>
@@ -143,10 +143,10 @@ const ContentAnalytics: React.FC<ContentAnalyticsProps> = ({ items, className = 
           {Object.entries(analytics.difficultyCounts).map(([difficulty, count]) => {
             const percentage = (count / analytics.totalItems) * 100;
             const difficultyColor = {
-              'beginner': 'text-cortex-success bg-cortex-success/10 border-cortex-success/30',
-              'intermediate': 'text-cortex-info bg-cortex-info/10 border-cortex-info/30',
-              'advanced': 'text-cortex-warning bg-cortex-warning/10 border-cortex-warning/30',
-              'expert': 'text-cortex-error bg-cortex-error/10 border-cortex-error/30'
+              'beginner': 'text-status-success bg-status-success/10 border-status-success/30',
+              'intermediate': 'text-status-info bg-status-info/10 border-status-info/30',
+              'advanced': 'text-status-warning bg-status-warning/10 border-status-warning/30',
+              'expert': 'text-status-error bg-status-error/10 border-status-error/30'
             }[difficulty] || 'text-cortex-text-muted bg-cortex-bg-tertiary';
 
             return (
@@ -208,7 +208,7 @@ const ContentAnalytics: React.FC<ContentAnalyticsProps> = ({ items, className = 
                     <span className="text-cortex-text-secondary">
                       {category.replace('-', ' ')}
                     </span>
-                    <span className="font-bold text-cortex-green">{count}</span>
+                    <span className="font-bold text-cortex-primary">{count}</span>
                   </div>
                 ))}
             </div>
@@ -219,15 +219,15 @@ const ContentAnalytics: React.FC<ContentAnalyticsProps> = ({ items, className = 
             <div className="space-y-3">
               <div className="flex justify-between items-center">
                 <span className="text-cortex-text-secondary">This month</span>
-                <span className="font-bold text-cortex-info">+3 items</span>
+                <span className="font-bold text-status-info">+3 items</span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-cortex-text-secondary">Last month</span>
-                <span className="font-bold text-cortex-info">+5 items</span>
+                <span className="font-bold text-status-info">+5 items</span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-cortex-text-secondary">Total growth</span>
-                <span className="font-bold text-cortex-green">+8 items</span>
+                <span className="font-bold text-cortex-primary">+8 items</span>
               </div>
             </div>
           </div>
@@ -297,7 +297,7 @@ const ContentAnalytics: React.FC<ContentAnalyticsProps> = ({ items, className = 
             Import content from a JSON export file to expand your library.
           </p>
           <div className="space-y-4">
-            <div className="p-4 bg-cortex-bg-tertiary rounded-lg border-2 border-dashed border-cortex-border-secondary">
+            <div className="p-4 bg-cortex-bg-tertiary rounded-lg border-2 border-dashed border-cortex-border/40">
               <input
                 type="file"
                 accept=".json"
@@ -322,17 +322,17 @@ const ContentAnalytics: React.FC<ContentAnalyticsProps> = ({ items, className = 
           <h3 className="text-xl font-bold text-cortex-text-primary mb-4">📊 Export Summary</h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div className="text-center">
-              <div className="text-2xl font-bold text-cortex-green mb-1">{analytics.totalItems}</div>
+              <div className="text-2xl font-bold text-cortex-primary mb-1">{analytics.totalItems}</div>
               <div className="text-sm text-cortex-text-secondary">Items to Export</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-cortex-info mb-1">
+              <div className="text-2xl font-bold text-status-info mb-1">
                 {Object.keys(analytics.categoryCounts).length}
               </div>
               <div className="text-sm text-cortex-text-secondary">Categories</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-cortex-warning mb-1">
+              <div className="text-2xl font-bold text-status-warning mb-1">
                 {Math.round(analytics.avgRating * 10) / 10}
               </div>
               <div className="text-sm text-cortex-text-secondary">Avg Rating</div>
@@ -376,7 +376,7 @@ const ContentAnalytics: React.FC<ContentAnalyticsProps> = ({ items, className = 
               onClick={() => setActiveView(view.id as any)}
               className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
                 activeView === view.id
-                  ? 'bg-cortex-green text-black'
+                  ? 'bg-cortex-primary text-black'
                   : 'text-cortex-text-secondary hover:text-cortex-text-primary hover:bg-cortex-bg-hover'
               }`}
             >

--- a/hosting/components/ContentLibrary.tsx
+++ b/hosting/components/ContentLibrary.tsx
@@ -402,10 +402,10 @@ const ContentLibrary: React.FC<ContentLibraryProps> = ({
 
   const getDifficultyColor = (difficulty: string) => {
     const colors = {
-      beginner: 'text-cortex-success bg-cortex-success/10 border-cortex-success/30',
-      intermediate: 'text-cortex-info bg-cortex-info/10 border-cortex-info/30',
-      advanced: 'text-cortex-warning bg-cortex-warning/10 border-cortex-warning/30',
-      expert: 'text-cortex-error bg-cortex-error/10 border-cortex-error/30'
+      beginner: 'text-status-success bg-status-success/10 border-status-success/30',
+      intermediate: 'text-status-info bg-status-info/10 border-status-info/30',
+      advanced: 'text-status-warning bg-status-warning/10 border-status-warning/30',
+      expert: 'text-status-error bg-status-error/10 border-status-error/30'
     };
     return colors[difficulty as keyof typeof colors] || colors.beginner;
   };
@@ -427,7 +427,7 @@ const ContentLibrary: React.FC<ContentLibraryProps> = ({
     
     if (viewMode === 'list') {
       return (
-        <div key={item.id} className="cortex-card p-4 hover:border-cortex-green/50 transition-all">
+        <div key={item.id} className="cortex-card p-4 hover:border-cortex-primary/50 transition-all">
           <div className="flex items-start justify-between">
             <div className="flex-1">
               <div className="flex items-center space-x-3 mb-2">
@@ -462,7 +462,7 @@ const ContentLibrary: React.FC<ContentLibraryProps> = ({
             <div className="flex items-center space-x-2 ml-4">
               <button
                 onClick={() => toggleFavorite(item.id)}
-                className={`p-2 rounded ${isFavorited ? 'text-cortex-warning' : 'text-cortex-text-muted hover:text-cortex-warning'}`}
+                className={`p-2 rounded ${isFavorited ? 'text-status-warning' : 'text-cortex-text-muted hover:text-status-warning'}`}
               >
                 {isFavorited ? '★' : '☆'}
               </button>
@@ -491,12 +491,12 @@ const ContentLibrary: React.FC<ContentLibraryProps> = ({
     }
 
     return (
-      <div key={item.id} className="cortex-card p-4 hover:border-cortex-green/50 transition-all">
+      <div key={item.id} className="cortex-card p-4 hover:border-cortex-primary/50 transition-all">
         <div className="flex items-start justify-between mb-3">
           <span className="text-3xl">{getCategoryIcon(item.category)}</span>
           <button
             onClick={() => toggleFavorite(item.id)}
-            className={`text-lg ${isFavorited ? 'text-cortex-warning' : 'text-cortex-text-muted hover:text-cortex-warning'}`}
+            className={`text-lg ${isFavorited ? 'text-status-warning' : 'text-cortex-text-muted hover:text-status-warning'}`}
           >
             {isFavorited ? '★' : '☆'}
           </button>
@@ -553,13 +553,13 @@ const ContentLibrary: React.FC<ContentLibraryProps> = ({
         <div className="flex items-center space-x-2">
           <button
             onClick={() => setViewMode('grid')}
-            className={`p-2 rounded ${viewMode === 'grid' ? 'bg-cortex-green text-white' : 'text-cortex-text-muted hover:text-cortex-text-primary'}`}
+            className={`p-2 rounded ${viewMode === 'grid' ? 'bg-cortex-primary text-white' : 'text-cortex-text-muted hover:text-cortex-text-primary'}`}
           >
             ⊞
           </button>
           <button
             onClick={() => setViewMode('list')}
-            className={`p-2 rounded ${viewMode === 'list' ? 'bg-cortex-green text-white' : 'text-cortex-text-muted hover:text-cortex-text-primary'}`}
+            className={`p-2 rounded ${viewMode === 'list' ? 'bg-cortex-primary text-white' : 'text-cortex-text-muted hover:text-cortex-text-primary'}`}
           >
             ☰
           </button>
@@ -574,7 +574,7 @@ const ContentLibrary: React.FC<ContentLibraryProps> = ({
             placeholder="Search content..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full px-3 py-2 bg-cortex-bg-secondary border border-cortex-border-secondary rounded text-cortex-text-primary placeholder-cortex-text-muted focus:border-cortex-green focus:outline-none"
+            className="w-full px-3 py-2 bg-cortex-bg-secondary border border-cortex-border/40 rounded text-cortex-text-primary placeholder-cortex-text-muted focus:border-cortex-primary focus:outline-none"
           />
         </div>
         
@@ -582,7 +582,7 @@ const ContentLibrary: React.FC<ContentLibraryProps> = ({
           <select
             value={selectedCategory}
             onChange={(e) => setSelectedCategory(e.target.value)}
-            className="w-full px-3 py-2 bg-cortex-bg-secondary border border-cortex-border-secondary rounded text-cortex-text-primary focus:border-cortex-green focus:outline-none"
+            className="w-full px-3 py-2 bg-cortex-bg-secondary border border-cortex-border/40 rounded text-cortex-text-primary focus:border-cortex-primary focus:outline-none"
           >
             {categories.map(category => (
               <option key={category.id} value={category.id}>
@@ -596,7 +596,7 @@ const ContentLibrary: React.FC<ContentLibraryProps> = ({
           <select
             value={selectedDifficulty}
             onChange={(e) => setSelectedDifficulty(e.target.value)}
-            className="w-full px-3 py-2 bg-cortex-bg-secondary border border-cortex-border-secondary rounded text-cortex-text-primary focus:border-cortex-green focus:outline-none"
+            className="w-full px-3 py-2 bg-cortex-bg-secondary border border-cortex-border/40 rounded text-cortex-text-primary focus:border-cortex-primary focus:outline-none"
           >
             {difficulties.map(difficulty => (
               <option key={difficulty.id} value={difficulty.id}>
@@ -610,7 +610,7 @@ const ContentLibrary: React.FC<ContentLibraryProps> = ({
           <select
             value={sortBy}
             onChange={(e) => setSortBy(e.target.value as any)}
-            className="w-full px-3 py-2 bg-cortex-bg-secondary border border-cortex-border-secondary rounded text-cortex-text-primary focus:border-cortex-green focus:outline-none"
+            className="w-full px-3 py-2 bg-cortex-bg-secondary border border-cortex-border/40 rounded text-cortex-text-primary focus:border-cortex-primary focus:outline-none"
           >
             <option value="rating">Sort by Rating</option>
             <option value="usage">Sort by Usage</option>
@@ -623,21 +623,21 @@ const ContentLibrary: React.FC<ContentLibraryProps> = ({
       {/* Stats */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <div className="cortex-card p-4 text-center">
-          <div className="text-2xl font-bold text-cortex-green">{filteredContent.length}</div>
+          <div className="text-2xl font-bold text-cortex-primary">{filteredContent.length}</div>
           <div className="text-sm text-cortex-text-secondary">Items Found</div>
         </div>
         <div className="cortex-card p-4 text-center">
-          <div className="text-2xl font-bold text-cortex-info">{favorites.size}</div>
+          <div className="text-2xl font-bold text-status-info">{favorites.size}</div>
           <div className="text-sm text-cortex-text-secondary">Favorites</div>
         </div>
         <div className="cortex-card p-4 text-center">
-          <div className="text-2xl font-bold text-cortex-warning">
+          <div className="text-2xl font-bold text-status-warning">
             {categories.filter(c => c.id !== 'all').length}
           </div>
           <div className="text-sm text-cortex-text-secondary">Categories</div>
         </div>
         <div className="cortex-card p-4 text-center">
-          <div className="text-2xl font-bold text-cortex-text-accent">
+          <div className="text-2xl font-bold text-cortex-accent">
             {Math.round(CONTENT_LIBRARY.reduce((acc, item) => acc + item.rating, 0) / CONTENT_LIBRARY.length * 10) / 10}
           </div>
           <div className="text-sm text-cortex-text-secondary">Avg Rating</div>

--- a/hosting/components/EnhancedTerminalSidebar.tsx
+++ b/hosting/components/EnhancedTerminalSidebar.tsx
@@ -29,10 +29,10 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
   const [sidebarSize, setSidebarSize] = useState<SidebarSize>(defaultExpanded ? 'standard' : 'minimized');
   const [isResizing, setIsResizing] = useState(false);
   const [quickCommands] = useState([
-    { name: 'POV Status', command: 'pov status --current', icon: '📊', color: 'text-cortex-green' },
-    { name: 'List Scenarios', command: 'scenario list', icon: '📋', color: 'text-cortex-info' },
-    { name: 'Deploy Latest', command: 'scenario deploy --latest', icon: '🚀', color: 'text-cortex-warning' },
-    { name: 'Generate Report', command: 'pov report --executive', icon: '📄', color: 'text-cortex-text-accent' }
+    { name: 'POV Status', command: 'pov status --current', icon: '📊', color: 'text-cortex-primary' },
+    { name: 'List Scenarios', command: 'scenario list', icon: '📋', color: 'text-status-info' },
+    { name: 'Deploy Latest', command: 'scenario deploy --latest', icon: '🚀', color: 'text-status-warning' },
+    { name: 'Generate Report', command: 'pov report --executive', icon: '📄', color: 'text-cortex-accent' }
   ]);
   
   const terminalRef = useRef<ImprovedTerminalRef>(null);
@@ -104,7 +104,7 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
     <div
       ref={sidebarRef}
       className={cn(
-        'fixed right-0 top-0 h-full bg-gradient-to-b from-gray-900 via-gray-800 to-gray-900 border-l border-gray-700 shadow-2xl transition-all duration-300 ease-in-out z-40',
+        'fixed right-0 top-0 h-full bg-gradient-to-b from-cortex-bg-secondary via-cortex-bg-tertiary to-cortex-bg-secondary border-l border-cortex-border/60 shadow-cortex-xl transition-all duration-300 ease-in-out z-40 backdrop-blur-xl',
         SIDEBAR_WIDTHS[sidebarSize],
         'flex flex-col',
         className
@@ -114,17 +114,17 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
       {sidebarSize !== 'minimized' && (
         <div
           ref={resizeHandleRef}
-          className="absolute left-0 top-0 w-1 h-full cursor-col-resize bg-gray-600 hover:bg-cortex-green transition-colors opacity-0 hover:opacity-100"
+          className="absolute left-0 top-0 w-1 h-full cursor-col-resize bg-cortex-border-muted hover:bg-cortex-primary transition-colors opacity-0 hover:opacity-100"
           onMouseDown={startResize}
         />
       )}
 
       {/* Header Bar */}
-      <div className="flex items-center justify-between p-3 border-b border-gray-700 bg-gray-800/50">
+      <div className="flex items-center justify-between p-3 border-b border-cortex-border/50 bg-cortex-bg-tertiary/60">
         {sidebarSize === 'minimized' ? (
           <button
             onClick={toggleSidebar}
-            className="w-8 h-8 flex items-center justify-center text-cortex-text-secondary hover:text-cortex-green transition-colors rounded-md hover:bg-gray-700"
+            className="w-8 h-8 flex items-center justify-center text-cortex-text-secondary hover:text-cortex-primary transition-colors rounded-md hover:bg-cortex-bg-hover/80"
             title="Open Terminal"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -135,11 +135,11 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
           <>
             <div className="flex items-center space-x-2">
               <div className="flex items-center space-x-1">
-                <div className="w-2 h-2 bg-red-400 rounded-full"></div>
-                <div className="w-2 h-2 bg-yellow-400 rounded-full"></div>
-                <div className="w-2 h-2 bg-green-400 rounded-full"></div>
+                <div className="w-2 h-2 bg-status-error rounded-full"></div>
+                <div className="w-2 h-2 bg-status-warning rounded-full"></div>
+                <div className="w-2 h-2 bg-status-success rounded-full"></div>
               </div>
-              <span className="text-sm font-medium text-gray-300">Terminal</span>
+              <span className="text-sm font-medium text-cortex-text-secondary">Terminal</span>
             </div>
             
             <div className="flex items-center space-x-1">
@@ -149,7 +149,7 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
                   onClick={() => setSizeMode('compact')}
                   className={cn(
                     'w-5 h-5 flex items-center justify-center rounded text-xs transition-colors',
-                    sidebarSize === 'compact' ? 'bg-cortex-green text-gray-900' : 'text-cortex-text-secondary hover:text-cortex-green hover:bg-gray-700'
+                    sidebarSize === 'compact' ? 'bg-cortex-primary text-cortex-dark' : 'text-cortex-text-secondary hover:text-cortex-primary hover:bg-cortex-bg-hover/80'
                   )}
                   title="Compact view"
                 >
@@ -159,7 +159,7 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
                   onClick={() => setSizeMode('standard')}
                   className={cn(
                     'w-5 h-5 flex items-center justify-center rounded text-xs transition-colors',
-                    sidebarSize === 'standard' ? 'bg-cortex-green text-gray-900' : 'text-cortex-text-secondary hover:text-cortex-green hover:bg-gray-700'
+                    sidebarSize === 'standard' ? 'bg-cortex-primary text-cortex-dark' : 'text-cortex-text-secondary hover:text-cortex-primary hover:bg-cortex-bg-hover/80'
                   )}
                   title="Standard view"
                 >
@@ -169,7 +169,7 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
                   onClick={() => setSizeMode('expanded')}
                   className={cn(
                     'w-5 h-5 flex items-center justify-center rounded text-xs transition-colors',
-                    sidebarSize === 'expanded' ? 'bg-cortex-green text-gray-900' : 'text-cortex-text-secondary hover:text-cortex-green hover:bg-gray-700'
+                    sidebarSize === 'expanded' ? 'bg-cortex-primary text-cortex-dark' : 'text-cortex-text-secondary hover:text-cortex-primary hover:bg-cortex-bg-hover/80'
                   )}
                   title="Expanded view"
                 >
@@ -180,7 +180,7 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
               {/* Minimize Button */}
               <button
                 onClick={toggleSidebar}
-                className="w-7 h-7 flex items-center justify-center text-cortex-text-secondary hover:text-cortex-warning transition-colors rounded-md hover:bg-gray-700"
+                className="w-7 h-7 flex items-center justify-center text-cortex-text-secondary hover:text-status-warning transition-colors rounded-md hover:bg-cortex-bg-hover/80"
                 title="Minimize Terminal"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -194,7 +194,7 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
                   setSidebarSize('minimized');
                   actions.closeTerminal();
                 }}
-                className="w-7 h-7 flex items-center justify-center text-cortex-text-secondary hover:text-red-400 transition-colors rounded-md hover:bg-gray-700"
+                className="w-7 h-7 flex items-center justify-center text-cortex-text-secondary hover:text-status-error transition-colors rounded-md hover:bg-cortex-bg-hover/80"
                 title="Close Terminal"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -208,7 +208,7 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
 
       {/* Quick Commands Bar */}
       {isVisible && (
-        <div className="flex-shrink-0 p-3 border-b border-gray-700 bg-gray-800/30">
+      <div className="flex-shrink-0 p-3 border-b border-cortex-border/40 bg-cortex-bg-tertiary/40">
           <div className="text-xs text-cortex-text-secondary mb-2 font-medium">Quick Commands</div>
           <div className="grid grid-cols-2 gap-2">
             {quickCommands.map((cmd, index) => (
@@ -216,8 +216,8 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
                 key={index}
                 onClick={() => executeQuickCommand(cmd.command)}
                 className={cn(
-                  'flex items-center space-x-2 p-2 rounded-lg border border-gray-600 hover:border-gray-500 transition-all duration-200 hover:shadow-md text-left',
-                  'bg-gray-800/50 hover:bg-gray-700/50'
+                  'flex items-center space-x-2 p-2 rounded-lg border border-cortex-border/60 hover:border-cortex-border transition-all duration-200 hover:shadow-cortex-sm text-left',
+                  'bg-cortex-bg-tertiary/60 hover:bg-cortex-bg-hover/50'
                 )}
                 title={cmd.command}
               >
@@ -237,7 +237,7 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
       {isVisible && (
         <div className="flex-1 min-h-0 overflow-hidden">
           <div className="h-full p-2">
-            <div className="h-full rounded-lg border border-gray-600 bg-gray-900/50 overflow-hidden">
+            <div className="h-full rounded-lg border border-cortex-border/60 bg-cortex-bg-secondary/60 overflow-hidden">
               <ImprovedTerminal ref={terminalRef} />
             </div>
           </div>
@@ -246,15 +246,15 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
 
       {/* Status Bar */}
       {isVisible && (
-        <div className="flex-shrink-0 flex items-center justify-between px-3 py-2 border-t border-gray-700 bg-gray-800/50 text-xs text-cortex-text-secondary">
+        <div className="flex-shrink-0 flex items-center justify-between px-3 py-2 border-t border-cortex-border/40 bg-cortex-bg-tertiary/40 text-xs text-cortex-text-secondary">
           <div className="flex items-center space-x-3">
-            <div className="flex items-center space-x-1">
-              <div className="w-1.5 h-1.5 bg-green-400 rounded-full animate-pulse"></div>
+              <div className="flex items-center space-x-1">
+                <div className="w-1.5 h-1.5 bg-status-success rounded-full animate-pulse"></div>
               <span>Online</span>
             </div>
             {state.data.currentPovId && (
               <div className="flex items-center space-x-1">
-                <span className="text-cortex-green">POV:</span>
+                <span className="text-cortex-primary">POV:</span>
                 <span className="font-mono">{state.data.currentPovId}</span>
               </div>
             )}
@@ -262,7 +262,7 @@ const EnhancedTerminalSidebar: React.FC<TerminalSidebarProps> = ({
           
           <div className="flex items-center space-x-2">
             <button
-              className="text-cortex-text-secondary hover:text-cortex-info transition-colors"
+              className="text-cortex-text-secondary hover:text-status-info transition-colors"
               title="Terminal Help"
               onClick={() => executeQuickCommand('help')}
             >

--- a/hosting/components/TRRManagement.tsx
+++ b/hosting/components/TRRManagement.tsx
@@ -235,12 +235,12 @@ const TRRCreationForm: React.FC<{
               type="text"
               value={formData.title}
               onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50 ${
-                errors.title ? 'border-cortex-error' : 'border-cortex-border-secondary'
+              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50 ${
+                errors.title ? 'border-status-error' : 'border-cortex-border/40'
               }`}
               placeholder="Enter TRR title"
             />
-            {errors.title && <p className="text-cortex-error text-sm mt-1">{errors.title}</p>}
+            {errors.title && <p className="text-status-error text-sm mt-1">{errors.title}</p>}
           </div>
 
           <div className="lg:col-span-2">
@@ -251,12 +251,12 @@ const TRRCreationForm: React.FC<{
               value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
               rows={4}
-              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50 resize-none ${
-                errors.description ? 'border-cortex-error' : 'border-cortex-border-secondary'
+              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50 resize-none ${
+                errors.description ? 'border-status-error' : 'border-cortex-border/40'
               }`}
               placeholder="Detailed description of the technical requirement"
             />
-            {errors.description && <p className="text-cortex-error text-sm mt-1">{errors.description}</p>}
+            {errors.description && <p className="text-status-error text-sm mt-1">{errors.description}</p>}
           </div>
         </div>
 
@@ -269,7 +269,7 @@ const TRRCreationForm: React.FC<{
             <select
               value={formData.category}
               onChange={(e) => setFormData({ ...formData, category: e.target.value as TRRCategory })}
-              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border-secondary rounded-lg text-cortex-text-primary focus:outline-none focus:ring-2 focus:ring-cortex-green/50"
+              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border/40 rounded-lg text-cortex-text-primary focus:outline-none focus:ring-2 focus:ring-cortex-primary/50"
             >
               <option value="security">Security</option>
               <option value="performance">Performance</option>
@@ -288,7 +288,7 @@ const TRRCreationForm: React.FC<{
             <select
               value={formData.priority}
               onChange={(e) => setFormData({ ...formData, priority: e.target.value as TRRPriority })}
-              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border-secondary rounded-lg text-cortex-text-primary focus:outline-none focus:ring-2 focus:ring-cortex-green/50"
+              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border/40 rounded-lg text-cortex-text-primary focus:outline-none focus:ring-2 focus:ring-cortex-primary/50"
             >
               <option value="low">Low</option>
               <option value="medium">Medium</option>
@@ -304,7 +304,7 @@ const TRRCreationForm: React.FC<{
             <select
               value={formData.riskLevel}
               onChange={(e) => setFormData({ ...formData, riskLevel: e.target.value as RiskLevel })}
-              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border-secondary rounded-lg text-cortex-text-primary focus:outline-none focus:ring-2 focus:ring-cortex-green/50"
+              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border/40 rounded-lg text-cortex-text-primary focus:outline-none focus:ring-2 focus:ring-cortex-primary/50"
             >
               <option value="low">Low Risk</option>
               <option value="medium">Medium Risk</option>
@@ -324,12 +324,12 @@ const TRRCreationForm: React.FC<{
               type="text"
               value={formData.assignedTo}
               onChange={(e) => setFormData({ ...formData, assignedTo: e.target.value })}
-              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50 ${
-                errors.assignedTo ? 'border-cortex-error' : 'border-cortex-border-secondary'
+              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50 ${
+                errors.assignedTo ? 'border-status-error' : 'border-cortex-border/40'
               }`}
               placeholder="Full name"
             />
-            {errors.assignedTo && <p className="text-cortex-error text-sm mt-1">{errors.assignedTo}</p>}
+            {errors.assignedTo && <p className="text-status-error text-sm mt-1">{errors.assignedTo}</p>}
           </div>
 
           <div>
@@ -340,12 +340,12 @@ const TRRCreationForm: React.FC<{
               type="email"
               value={formData.assignedToEmail}
               onChange={(e) => setFormData({ ...formData, assignedToEmail: e.target.value })}
-              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50 ${
-                errors.assignedToEmail ? 'border-cortex-error' : 'border-cortex-border-secondary'
+              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50 ${
+                errors.assignedToEmail ? 'border-status-error' : 'border-cortex-border/40'
               }`}
               placeholder="email@company.com"
             />
-            {errors.assignedToEmail && <p className="text-cortex-error text-sm mt-1">{errors.assignedToEmail}</p>}
+            {errors.assignedToEmail && <p className="text-status-error text-sm mt-1">{errors.assignedToEmail}</p>}
           </div>
         </div>
 
@@ -359,12 +359,12 @@ const TRRCreationForm: React.FC<{
               type="text"
               value={formData.customer}
               onChange={(e) => setFormData({ ...formData, customer: e.target.value })}
-              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50 ${
-                errors.customer ? 'border-cortex-error' : 'border-cortex-border-secondary'
+              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50 ${
+                errors.customer ? 'border-status-error' : 'border-cortex-border/40'
               }`}
               placeholder="Customer name"
             />
-            {errors.customer && <p className="text-cortex-error text-sm mt-1">{errors.customer}</p>}
+            {errors.customer && <p className="text-status-error text-sm mt-1">{errors.customer}</p>}
           </div>
 
           <div>
@@ -375,12 +375,12 @@ const TRRCreationForm: React.FC<{
               type="email"
               value={formData.customerContact}
               onChange={(e) => setFormData({ ...formData, customerContact: e.target.value })}
-              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50 ${
-                errors.customerContact ? 'border-cortex-error' : 'border-cortex-border-secondary'
+              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50 ${
+                errors.customerContact ? 'border-status-error' : 'border-cortex-border/40'
               }`}
               placeholder="contact@customer.com"
             />
-            {errors.customerContact && <p className="text-cortex-error text-sm mt-1">{errors.customerContact}</p>}
+            {errors.customerContact && <p className="text-status-error text-sm mt-1">{errors.customerContact}</p>}
           </div>
 
           <div>
@@ -391,7 +391,7 @@ const TRRCreationForm: React.FC<{
               type="text"
               value={formData.project}
               onChange={(e) => setFormData({ ...formData, project: e.target.value })}
-              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border-secondary rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50"
+              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border/40 rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50"
               placeholder="Project code/name"
             />
           </div>
@@ -404,7 +404,7 @@ const TRRCreationForm: React.FC<{
               type="text"
               value={formData.scenario}
               onChange={(e) => setFormData({ ...formData, scenario: e.target.value })}
-              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border-secondary rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50"
+              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border/40 rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50"
               placeholder="Related scenario"
             />
           </div>
@@ -419,7 +419,7 @@ const TRRCreationForm: React.FC<{
             <select
               value={formData.validationMethod}
               onChange={(e) => setFormData({ ...formData, validationMethod: e.target.value as ValidationMethod })}
-              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border-secondary rounded-lg text-cortex-text-primary focus:outline-none focus:ring-2 focus:ring-cortex-green/50"
+              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border/40 rounded-lg text-cortex-text-primary focus:outline-none focus:ring-2 focus:ring-cortex-primary/50"
             >
               <option value="manual">Manual Testing</option>
               <option value="automated">Automated Testing</option>
@@ -436,7 +436,7 @@ const TRRCreationForm: React.FC<{
             <select
               value={formData.complexity}
               onChange={(e) => setFormData({ ...formData, complexity: e.target.value as CreateTRRFormData['complexity'] })}
-              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border-secondary rounded-lg text-cortex-text-primary focus:outline-none focus:ring-2 focus:ring-cortex-green/50"
+              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border/40 rounded-lg text-cortex-text-primary focus:outline-none focus:ring-2 focus:ring-cortex-primary/50"
             >
               <option value="simple">Simple</option>
               <option value="moderate">Moderate</option>
@@ -456,7 +456,7 @@ const TRRCreationForm: React.FC<{
               type="date"
               value={formData.dueDate}
               onChange={(e) => setFormData({ ...formData, dueDate: e.target.value })}
-              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border-secondary rounded-lg text-cortex-text-primary focus:outline-none focus:ring-2 focus:ring-cortex-green/50"
+              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border/40 rounded-lg text-cortex-text-primary focus:outline-none focus:ring-2 focus:ring-cortex-primary/50"
             />
           </div>
 
@@ -468,7 +468,7 @@ const TRRCreationForm: React.FC<{
               type="number"
               value={formData.estimatedHours || ''}
               onChange={(e) => setFormData({ ...formData, estimatedHours: e.target.value ? parseInt(e.target.value) : undefined })}
-              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border-secondary rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50"
+              className="w-full px-4 py-3 bg-cortex-bg-tertiary border border-cortex-border/40 rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50"
               placeholder="Hours"
               min="0"
             />
@@ -485,12 +485,12 @@ const TRRCreationForm: React.FC<{
               value={formData.expectedOutcome}
               onChange={(e) => setFormData({ ...formData, expectedOutcome: e.target.value })}
               rows={3}
-              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50 resize-none ${
-                errors.expectedOutcome ? 'border-cortex-error' : 'border-cortex-border-secondary'
+              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50 resize-none ${
+                errors.expectedOutcome ? 'border-status-error' : 'border-cortex-border/40'
               }`}
               placeholder="Describe what success looks like"
             />
-            {errors.expectedOutcome && <p className="text-cortex-error text-sm mt-1">{errors.expectedOutcome}</p>}
+            {errors.expectedOutcome && <p className="text-status-error text-sm mt-1">{errors.expectedOutcome}</p>}
           </div>
 
           <div>
@@ -501,12 +501,12 @@ const TRRCreationForm: React.FC<{
               value={formData.businessImpact}
               onChange={(e) => setFormData({ ...formData, businessImpact: e.target.value })}
               rows={3}
-              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50 resize-none ${
-                errors.businessImpact ? 'border-cortex-error' : 'border-cortex-border-secondary'
+              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50 resize-none ${
+                errors.businessImpact ? 'border-status-error' : 'border-cortex-border/40'
               }`}
               placeholder="Explain the business impact and importance"
             />
-            {errors.businessImpact && <p className="text-cortex-error text-sm mt-1">{errors.businessImpact}</p>}
+            {errors.businessImpact && <p className="text-status-error text-sm mt-1">{errors.businessImpact}</p>}
           </div>
 
           <div>
@@ -517,12 +517,12 @@ const TRRCreationForm: React.FC<{
               value={formData.technicalRisk}
               onChange={(e) => setFormData({ ...formData, technicalRisk: e.target.value })}
               rows={3}
-              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50 resize-none ${
-                errors.technicalRisk ? 'border-cortex-error' : 'border-cortex-border-secondary'
+              className={`w-full px-4 py-3 bg-cortex-bg-tertiary border rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50 resize-none ${
+                errors.technicalRisk ? 'border-status-error' : 'border-cortex-border/40'
               }`}
               placeholder="Identify potential technical risks and challenges"
             />
-            {errors.technicalRisk && <p className="text-cortex-error text-sm mt-1">{errors.technicalRisk}</p>}
+            {errors.technicalRisk && <p className="text-status-error text-sm mt-1">{errors.technicalRisk}</p>}
           </div>
         </div>
 
@@ -539,7 +539,7 @@ const TRRCreationForm: React.FC<{
                   type="text"
                   value={criteria}
                   onChange={(e) => updateAcceptanceCriteria(index, e.target.value)}
-                  className="flex-1 px-4 py-2 bg-cortex-bg-tertiary border border-cortex-border-secondary rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50"
+                  className="flex-1 px-4 py-2 bg-cortex-bg-tertiary border border-cortex-border/40 rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50"
                   placeholder={`Acceptance criteria ${index + 1}`}
                 />
                 {formData.acceptanceCriteria.length > 1 && (
@@ -574,7 +574,7 @@ const TRRCreationForm: React.FC<{
             {formData.tags.map((tag, index) => (
               <span
                 key={index}
-                className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-cortex-bg-hover text-cortex-text-primary border border-cortex-border-secondary"
+                className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-cortex-bg-hover text-cortex-text-primary border border-cortex-border/40"
               >
                 {tag}
                 <button
@@ -591,7 +591,7 @@ const TRRCreationForm: React.FC<{
           <input
             type="text"
             placeholder="Add tag and press Enter"
-            className="w-full px-4 py-2 bg-cortex-bg-tertiary border border-cortex-border-secondary rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-green/50"
+            className="w-full px-4 py-2 bg-cortex-bg-tertiary border border-cortex-border/40 rounded-lg text-cortex-text-primary placeholder-cortex-text-muted focus:outline-none focus:ring-2 focus:ring-cortex-primary/50"
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ',') {
                 e.preventDefault();
@@ -606,7 +606,7 @@ const TRRCreationForm: React.FC<{
         </div>
 
         {/* Submit Buttons */}
-        <div className="flex justify-end space-x-4 pt-6 border-t border-cortex-border-secondary">
+        <div className="flex justify-end space-x-4 pt-6 border-t border-cortex-border/40">
           <CortexButton onClick={onCancel} variant="outline">
             Cancel
           </CortexButton>
@@ -632,12 +632,12 @@ const TRRList: React.FC<{
   const getStatusColor = (status: TRRStatus): string => {
     const colors = {
       'draft': 'text-cortex-text-muted bg-cortex-bg-hover',
-      'pending': 'text-cortex-warning bg-cortex-warning/10',
-      'in-progress': 'text-cortex-info bg-cortex-info/10',
-      'validated': 'text-cortex-green bg-cortex-green/10',
-      'failed': 'text-cortex-error bg-cortex-error/10',
+      'pending': 'text-status-warning bg-status-warning/10',
+      'in-progress': 'text-status-info bg-status-info/10',
+      'validated': 'text-cortex-primary bg-cortex-primary/10',
+      'failed': 'text-status-error bg-status-error/10',
       'not-applicable': 'text-cortex-text-muted bg-cortex-bg-hover',
-      'completed': 'text-cortex-green bg-cortex-green/10'
+      'completed': 'text-cortex-primary bg-cortex-primary/10'
     };
     return colors[status] || 'text-cortex-text-muted bg-cortex-bg-hover';
   };
@@ -645,9 +645,9 @@ const TRRList: React.FC<{
   const getPriorityColor = (priority: TRRPriority): string => {
     const colors = {
       'low': 'text-cortex-text-muted bg-cortex-bg-hover',
-      'medium': 'text-cortex-info bg-cortex-info/10',
-      'high': 'text-cortex-warning bg-cortex-warning/10',
-      'critical': 'text-cortex-error bg-cortex-error/10'
+      'medium': 'text-status-info bg-status-info/10',
+      'high': 'text-status-warning bg-status-warning/10',
+      'critical': 'text-status-error bg-status-error/10'
     };
     return colors[priority] || 'text-cortex-text-muted bg-cortex-bg-hover';
   };
@@ -655,14 +655,14 @@ const TRRList: React.FC<{
   return (
     <div className="cortex-card">
       {/* Header */}
-      <div className="p-6 border-b border-cortex-border-secondary">
+      <div className="p-6 border-b border-cortex-border/40">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
             <input
               type="checkbox"
               checked={selectedTRRs.length === trrs.length && trrs.length > 0}
               onChange={(e) => onSelectAll(e.target.checked)}
-              className="rounded border-cortex-border-secondary focus:ring-cortex-green"
+              className="rounded border-cortex-border/40 focus:ring-cortex-primary"
             />
             <h3 className="text-lg font-bold text-cortex-text-primary">
               TRR List ({trrs.length})
@@ -685,7 +685,7 @@ const TRRList: React.FC<{
       </div>
 
       {/* TRR List */}
-      <div className="divide-y divide-cortex-border-secondary">
+      <div className="divide-y divide-cortex-border/40">
         {trrs.map((trr) => (
           <div key={trr.id} className="p-6 hover:bg-cortex-bg-hover/50 transition-colors">
             <div className="flex items-start space-x-4">
@@ -693,17 +693,17 @@ const TRRList: React.FC<{
                 type="checkbox"
                 checked={selectedTRRs.includes(trr.id)}
                 onChange={(e) => onSelectTRR(trr.id, e.target.checked)}
-                className="mt-1 rounded border-cortex-border-secondary focus:ring-cortex-green"
+                className="mt-1 rounded border-cortex-border/40 focus:ring-cortex-primary"
               />
               
               <div className="flex-1 min-w-0">
                 {/* Header Row */}
                 <div className="flex items-start justify-between mb-3">
                   <div className="flex items-center space-x-3">
-                    <h4 className="text-lg font-semibold text-cortex-text-primary cursor-pointer hover:text-cortex-green" onClick={() => onView(trr)}>
+                    <h4 className="text-lg font-semibold text-cortex-text-primary cursor-pointer hover:text-cortex-primary" onClick={() => onView(trr)}>
                       {trr.title}
                     </h4>
-                    <span className="font-mono text-sm text-cortex-text-accent">
+                    <span className="font-mono text-sm text-cortex-accent">
                       {trr.id}
                     </span>
                   </div>
@@ -745,7 +745,7 @@ const TRRList: React.FC<{
                     {trr.tags.slice(0, 3).map((tag, index) => (
                       <span
                         key={index}
-                        className="px-2 py-1 text-xs bg-cortex-bg-tertiary text-cortex-text-muted rounded border border-cortex-border-secondary"
+                        className="px-2 py-1 text-xs bg-cortex-bg-tertiary text-cortex-text-muted rounded border border-cortex-border/40"
                       >
                         {tag}
                       </span>
@@ -792,9 +792,9 @@ const TRRList: React.FC<{
                   <div className="flex items-center space-x-2">
                     {trr.riskLevel !== 'low' && (
                       <span className={`px-2 py-1 text-xs font-medium rounded ${
-                        trr.riskLevel === 'critical' ? 'bg-cortex-error/10 text-cortex-error' :
-                        trr.riskLevel === 'high' ? 'bg-cortex-warning/10 text-cortex-warning' :
-                        'bg-cortex-info/10 text-cortex-info'
+                        trr.riskLevel === 'critical' ? 'bg-status-error/10 text-status-error' :
+                        trr.riskLevel === 'high' ? 'bg-status-warning/10 text-status-warning' :
+                        'bg-status-info/10 text-status-info'
                       }`}>
                         {trr.riskLevel.toUpperCase()} RISK
                       </span>
@@ -810,7 +810,7 @@ const TRRList: React.FC<{
                       size="sm"
                       icon="🗑️"
                       ariaLabel={`Delete TRR ${trr.id}`}
-                      className="text-cortex-error hover:text-cortex-error"
+                      className="text-status-error hover:text-status-error"
                     >
                       Delete
                     </CortexButton>
@@ -968,23 +968,23 @@ export const TRRManagement: React.FC = () => {
             <div className="text-sm text-cortex-text-secondary">Draft</div>
           </div>
           <div className="cortex-card p-4 text-center">
-            <div className="text-2xl font-bold text-cortex-info">{stats.inProgress}</div>
+            <div className="text-2xl font-bold text-status-info">{stats.inProgress}</div>
             <div className="text-sm text-cortex-text-secondary">In Progress</div>
           </div>
           <div className="cortex-card p-4 text-center">
-            <div className="text-2xl font-bold text-cortex-green">{stats.validated}</div>
+            <div className="text-2xl font-bold text-cortex-primary">{stats.validated}</div>
             <div className="text-sm text-cortex-text-secondary">Validated</div>
           </div>
           <div className="cortex-card p-4 text-center">
-            <div className="text-2xl font-bold text-cortex-green">{stats.completed}</div>
+            <div className="text-2xl font-bold text-cortex-primary">{stats.completed}</div>
             <div className="text-sm text-cortex-text-secondary">Completed</div>
           </div>
           <div className="cortex-card p-4 text-center">
-            <div className="text-2xl font-bold text-cortex-warning">{stats.overdue}</div>
+            <div className="text-2xl font-bold text-status-warning">{stats.overdue}</div>
             <div className="text-sm text-cortex-text-secondary">Overdue</div>
           </div>
           <div className="cortex-card p-4 text-center">
-            <div className="text-2xl font-bold text-cortex-error">{stats.critical}</div>
+            <div className="text-2xl font-bold text-status-error">{stats.critical}</div>
             <div className="text-sm text-cortex-text-secondary">Critical</div>
           </div>
         </div>

--- a/hosting/providers/ThemeProvider.tsx
+++ b/hosting/providers/ThemeProvider.tsx
@@ -86,64 +86,61 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
 // Theme configuration constants
 export const THEME_CONFIG = {
   colors: {
-    // Palo Alto Networks official brand colors
+    // Cortex Brand Palette mapped to CSS variables
     brand: {
-      primary: '#22c55e', // Palo Alto Networks Orange
-      secondary: '#8ad3de', // Cortex Teal
-      tertiary: '#00c0e8', // Cortex Blue
-      dark: '#141414', // Palo Alto Dark
+      primary: 'rgb(var(--cortex-primary, 0 204 102))',
+      secondary: 'rgb(var(--cortex-teal, 21 189 178))',
+      tertiary: 'rgb(var(--cortex-blue, 0 192 232))',
+      dark: 'rgb(var(--cortex-dark, 8 17 24))',
     },
-    
-    // Enhanced Cortex color system
+
     cortex: {
-      primary: '#00CC66', // Cortex Primary Green
-      primaryLight: '#33D580',
-      primaryDark: '#00B359',
-      secondary: '#22c55e', // Cortex Secondary Orange
-      secondaryLight: '#bbf7d0',
-      secondaryDark: '#15803d',
-      accent: '#58A6FF', // Cortex Accent Blue
-      accentLight: '#79B8FF',
-      accentDark: '#388BFD',
+      primary: 'rgb(var(--cortex-primary, 0 204 102))',
+      primaryLight: 'rgb(var(--cortex-primary-light, 54 231 149))',
+      primaryDark: 'rgb(var(--cortex-primary-dark, 0 156 78))',
+      secondary: 'rgb(var(--cortex-teal, 21 189 178))',
+      tertiary: 'rgb(var(--cortex-blue, 0 192 232))',
+      teal: 'rgb(var(--cortex-teal, 21 189 178))',
+      blue: 'rgb(var(--cortex-blue, 0 192 232))',
+      cyan: 'rgb(var(--cortex-cyan, 0 214 255))',
+      purple: 'rgb(var(--cortex-purple, 130 125 255))',
+      accent: 'rgb(var(--cortex-accent, 120 220 255))',
     },
-    
-    // Background system for dark theme
+
     background: {
-      primary: '#000000',
-      secondary: '#0D1117',
-      tertiary: '#161B22',
-      quaternary: '#21262D',
-      hover: '#30363D',
+      primary: 'var(--cortex-bg-primary, #050C11)',
+      secondary: 'var(--cortex-bg-secondary, #081118)',
+      tertiary: 'var(--cortex-bg-tertiary, #0E1A22)',
+      quaternary: 'var(--cortex-bg-quaternary, #13232D)',
+      hover: 'var(--cortex-bg-hover, #1A303C)',
     },
-    
-    // Text hierarchy
+
     text: {
-      primary: '#F0F6FC',
-      secondary: '#C9D1D9',
-      muted: '#8B949E',
-      disabled: '#6E7681',
+      primary: 'rgb(var(--cortex-text-primary, 224 244 239))',
+      secondary: 'rgb(var(--cortex-text-secondary, 188 214 207))',
+      muted: 'rgb(var(--cortex-text-muted, 148 173 168))',
+      disabled: 'rgb(var(--cortex-text-disabled, 110 130 126))',
     },
-    
-    // Status colors
+
     status: {
-      success: '#00CC66',
-      successBg: '#0D2818',
-      warning: '#F1C40F',
-      warningBg: '#2B2000',
-      error: '#F85149',
-      errorBg: '#2D0F0F',
-      info: '#58A6FF',
-      infoBg: '#0C1D2E',
+      success: 'rgb(var(--status-success, 0 204 140))',
+      successBg: 'rgba(var(--status-success, 0 204 140), 0.12)',
+      warning: 'rgb(var(--status-warning, 255 171 38))',
+      warningBg: 'rgba(var(--status-warning, 255 171 38), 0.14)',
+      error: 'rgb(var(--status-error, 239 83 80))',
+      errorBg: 'rgba(var(--status-error, 239 83 80), 0.14)',
+      info: 'rgb(var(--status-info, 32 196 255))',
+      infoBg: 'rgba(var(--status-info, 32 196 255), 0.14)',
     },
-    
-    // Border system
+
     border: {
-      primary: '#30363D',
-      secondary: '#21262D',
-      accent: '#00CC66',
-      error: '#F85149',
-      warning: '#F1C40F',
-      info: '#58A6FF',
+      primary: 'rgb(var(--cortex-border, 28 44 54))',
+      secondary: 'rgb(var(--cortex-border-secondary, 46 70 82))',
+      muted: 'rgb(var(--cortex-border-muted, 64 88 100))',
+      accent: 'rgb(var(--cortex-primary, 0 204 102))',
+      warning: 'rgb(var(--status-warning, 255 171 38))',
+      error: 'rgb(var(--status-error, 239 83 80))',
+      info: 'rgb(var(--status-info, 32 196 255))',
     }
   },
   
@@ -181,15 +178,15 @@ export const THEME_CONFIG = {
   // Component variants
   variants: {
     button: {
-      primary: 'bg-cortex-primary hover:bg-cortex-primary-light text-black font-semibold transition-all duration-300',
-      secondary: 'bg-cortex-bg-quaternary hover:bg-cortex-bg-hover border border-cortex-border-primary text-cortex-text-primary',
-      outline: 'border border-cortex-primary text-cortex-primary hover:bg-cortex-primary hover:text-black',
+      primary: 'bg-gradient-to-r from-cortex-primary to-cortex-blue text-white shadow-cortex-md hover:shadow-cortex-lg transition-all duration-300',
+      secondary: 'bg-cortex-bg-quaternary/80 hover:bg-cortex-bg-hover border border-cortex-border text-cortex-text-primary',
+      outline: 'border border-cortex-border text-cortex-text-primary hover:border-cortex-primary hover:text-cortex-primary',
       ghost: 'text-cortex-primary hover:bg-cortex-primary/10',
-      danger: 'bg-cortex-error hover:bg-cortex-error-light text-white',
+      danger: 'bg-status-error hover:bg-status-error/90 text-white',
     },
     card: {
-      default: 'bg-cortex-bg-tertiary border border-cortex-border-primary rounded-lg',
-      elevated: 'bg-cortex-bg-quaternary border border-cortex-border-primary rounded-lg shadow-cortex-lg',
+      default: 'bg-cortex-bg-tertiary border border-cortex-border rounded-lg',
+      elevated: 'bg-cortex-bg-quaternary border border-cortex-border-secondary rounded-lg shadow-cortex-lg',
       glass: 'glass-card rounded-lg',
       terminal: 'glass-terminal rounded-lg',
     }

--- a/hosting/tailwind.config.js
+++ b/hosting/tailwind.config.js
@@ -16,104 +16,155 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        // MODERN: Official Cortex Brand Colors (Token-based)
         cortex: {
           primary: withOpacity('--cortex-primary'),
+          'primary-dark': withOpacity('--cortex-primary-dark'),
+          'primary-light': withOpacity('--cortex-primary-light'),
+          green: withOpacity('--cortex-green'),
           teal: withOpacity('--cortex-teal'),
           blue: withOpacity('--cortex-blue'),
-          dark: withOpacity('--cortex-dark'),
-          // Text tokens
-          'text-primary': withOpacity('--cortex-text-primary'),
-          'text-secondary': withOpacity('--cortex-text-secondary'),
-          'text-muted': withOpacity('--cortex-text-muted'),
-          // Surfaces
+          cyan: withOpacity('--cortex-cyan'),
+          purple: withOpacity('--cortex-purple'),
+          accent: withOpacity('--cortex-accent'),
           canvas: withOpacity('--cortex-canvas'),
           surface: withOpacity('--cortex-surface'),
           elevated: withOpacity('--cortex-elevated'),
           border: withOpacity('--cortex-border'),
+          'border-strong': withOpacity('--cortex-border-strong'),
+          'border-secondary': withOpacity('--cortex-border-secondary'),
+          'border-muted': withOpacity('--cortex-border-muted'),
+          dark: withOpacity('--cortex-dark'),
+          'text-primary': withOpacity('--cortex-text-primary'),
+          'text-secondary': withOpacity('--cortex-text-secondary'),
+          'text-muted': withOpacity('--cortex-text-muted'),
+          'text-disabled': withOpacity('--cortex-text-disabled'),
+          'bg-primary': withOpacity('--cortex-bg-primary'),
+          'bg-secondary': withOpacity('--cortex-bg-secondary'),
+          'bg-tertiary': withOpacity('--cortex-bg-tertiary'),
+          'bg-quaternary': withOpacity('--cortex-bg-quaternary'),
+          'bg-hover': withOpacity('--cortex-bg-hover'),
         },
-        
-        // Status Colors (WCAG Compliant)
         status: {
           success: withOpacity('--status-success'),
           warning: withOpacity('--status-warning'),
           error: withOpacity('--status-error'),
           info: withOpacity('--status-info'),
         },
-        
-        // Focus & Ring Colors
         ring: {
           brand: withOpacity('--ring-brand'),
           focus: withOpacity('--ring-focus'),
         },
-        
-        // LEGACY: Brand Colors (preserved for compatibility)
-        'pan-orange': '#FA582D',           // Primary Palo Alto Networks orange
-        'pan-orange-dark': '#da532c',      // Darker orange variant
-        'pan-gray': '#141414',             // Primary text color
-        'cortex-primary': '#FA582D',       // Cortex primary (matches Palo Alto)
-        'cortex-teal': '#8ad3de',         // Cortex accent teal
-        'cortex-blue': '#00c0e8',         // Cortex interactive blue
-        'cortex-dark': '#141414',         // Cortex dark text
-        
-        // Official Cortex XSIAM Brand Colors
-        'cortex-primary': '#00CC66',     // Primary Cortex green
-        'cortex-primary-light': '#33D580', // Light green
-        'cortex-primary-dark': '#00B359',  // Dark green
-        'cortex-gray': '#6B7280',        // UI gray
-        'cortex-gray-dark': '#374151',   // Dark gray
-        'cortex-gray-light': '#F3F4F6',  // Light gray
-        'cortex-accent': '#FA582D',      // PANW orange accent
-        
-        // Legacy compatibility
-        'cortex-green': '#00CC66',
-        'cortex-green-light': '#33D580',
-        'cortex-green-dark': '#00B359',
-        
-        // LEGACY: Dark theme backgrounds - PRESERVED
-        'cortex-bg-primary': '#000000',
-        'cortex-bg-secondary': '#0D1117',
-        'cortex-bg-tertiary': '#161B22',
-        'cortex-bg-quaternary': '#21262D',
-        'cortex-bg-hover': '#30363D',
-        
-        // LEGACY: Text hierarchy - ENHANCED VISIBILITY & CONTRAST
-        'cortex-text-primary': '#FFFFFF',
-        'cortex-text-secondary': '#F5F5F5',
-        'cortex-text-muted': '#C8C8C8',
-        'cortex-text-disabled': '#A0A0A0',
-        'cortex-text-accent': '#58A6FF',
-        
-        // LEGACY: Border system - PRESERVED
-        'cortex-border-primary': '#FF6900',
-        'cortex-border-secondary': '#30363D',
-        'cortex-border-muted': '#21262D',
-        'cortex-border-accent': '#00CC66',
-        
-        // LEGACY: Status colors - PRESERVED
-        'cortex-success': '#00CC66',
-        'cortex-success-light': '#33D580',
-        'cortex-success-dark': '#00B359',
-        'cortex-success-bg': '#0D2818',
-        'cortex-success-border': '#00CC66',
-        
-        'cortex-warning': '#FF6900',
-        'cortex-warning-light': '#FF8533',
-        'cortex-warning-dark': '#E55A00',
-        'cortex-warning-bg': '#2B1A00',
-        'cortex-warning-border': '#FF6900',
-        
-        'cortex-error': '#F85149',
-        'cortex-error-light': '#FF7B72',
-        'cortex-error-dark': '#DA3633',
-        'cortex-error-bg': '#2D0F0F',
-        'cortex-error-border': '#F85149',
-        
-        'cortex-info': '#58A6FF',
-        'cortex-info-light': '#79B8FF',
-        'cortex-info-dark': '#388BFD',
-        'cortex-info-bg': '#0C1D2E',
-        'cortex-info-border': '#58A6FF',
+        semantic: {
+          success: withOpacity('--status-success'),
+          warning: withOpacity('--status-warning'),
+          danger: withOpacity('--status-error'),
+          info: withOpacity('--status-info'),
+        },
+        neutral: {
+          900: '#071018',
+          800: '#0b1620',
+          700: '#10202b',
+          600: '#1a2f3c',
+          500: '#2a3f4f',
+          400: '#3c5668',
+          300: '#567186',
+          200: '#7f9ab0',
+          100: '#b3ccd9',
+          50: '#e5f2f7',
+        },
+        white: '#ffffff',
+        black: '#000000',
+        gray: {
+          950: '#020508',
+          900: '#050C11',
+          800: '#081118',
+          700: '#0E1A22',
+          600: '#16242D',
+          500: '#1F303A',
+          400: '#2C3D49',
+          300: '#405564',
+          200: '#5C7383',
+          100: '#7F9AA7',
+          50: '#AFC5CE',
+        },
+        blue: {
+          950: '#011E28',
+          900: '#023546',
+          800: '#034C63',
+          700: '#04637F',
+          600: '#058AAB',
+          500: '#00C0E8',
+          400: '#33D6F1',
+          300: '#66E3F7',
+          200: '#99F0FB',
+          100: '#CCF9FD',
+          50: '#EAFDFF',
+        },
+        cyan: {
+          950: '#021E26',
+          900: '#02343F',
+          800: '#044C59',
+          700: '#066372',
+          600: '#088A9B',
+          500: '#00D6FF',
+          400: '#33E0FF',
+          300: '#66EBFF',
+          200: '#99F4FF',
+          100: '#CCFAFF',
+          50: '#E6FDFF',
+        },
+        green: {
+          950: '#02170D',
+          900: '#032612',
+          800: '#05361A',
+          700: '#074D26',
+          600: '#0A6432',
+          500: '#00CC66',
+          400: '#2EDF88',
+          300: '#63EAA8',
+          200: '#97F3C7',
+          100: '#C7FADF',
+          50: '#E8FDF1',
+        },
+        purple: {
+          950: '#1A1334',
+          900: '#241948',
+          800: '#2F1F5D',
+          700: '#3C2677',
+          600: '#4A3196',
+          500: '#827DFF',
+          400: '#9B95FF',
+          300: '#B6B0FF',
+          200: '#D0CBFF',
+          100: '#E6E3FF',
+          50: '#F4F2FF',
+        },
+        red: {
+          950: '#2A0608',
+          900: '#3F0B0F',
+          800: '#5A1116',
+          700: '#7A191E',
+          600: '#A0242A',
+          500: '#EF5350',
+          400: '#F7706D',
+          300: '#FA9A99',
+          200: '#FDC5C4',
+          100: '#FFE2E1',
+          50: '#FFF4F3',
+        },
+        yellow: {
+          950: '#1F1400',
+          900: '#2C1E02',
+          800: '#3E2B05',
+          700: '#563A09',
+          600: '#714C0F',
+          500: '#FFAB26',
+          400: '#FFBF59',
+          300: '#FFD58C',
+          200: '#FFE5B5',
+          100: '#FFF2D8',
+          50: '#FFF9ED',
+        },
       },
       
       // Default border colors using modern tokens  
@@ -136,15 +187,15 @@ module.exports = {
         'glass-lg': '0 8px 32px rgb(0 0 0 / 0.3), 0 16px 64px rgb(0 0 0 / 0.15)',
         
         // Brand shadows
-        'cortex-sm': '0 1px 2px 0 rgba(250, 88, 45, 0.1)',
-        'cortex-md': '0 4px 6px -1px rgba(250, 88, 45, 0.15), 0 2px 4px -1px rgba(250, 88, 45, 0.1)',
-        'cortex-lg': '0 10px 15px -3px rgba(250, 88, 45, 0.15), 0 4px 6px -2px rgba(250, 88, 45, 0.1)',
-        'cortex-xl': '0 20px 25px -5px rgba(250, 88, 45, 0.15), 0 10px 10px -5px rgba(250, 88, 45, 0.1)',
-        
+        'cortex-sm': '0 2px 4px rgba(0, 204, 140, 0.12)',
+        'cortex-md': '0 6px 14px rgba(0, 204, 140, 0.18), 0 3px 8px rgba(0, 192, 232, 0.12)',
+        'cortex-lg': '0 14px 28px rgba(0, 192, 232, 0.2), 0 6px 16px rgba(0, 204, 140, 0.18)',
+        'cortex-xl': '0 24px 48px rgba(0, 192, 232, 0.25), 0 12px 24px rgba(0, 204, 140, 0.2)',
+
         // Glow effects
-        'glow-brand': '0 0 20px rgba(250, 88, 45, 0.4), 0 0 40px rgba(250, 88, 45, 0.2)',
-        'glow-success': '0 0 20px rgba(22, 163, 74, 0.4), 0 0 40px rgba(22, 163, 74, 0.2)',
-        'glow-blue': '0 0 20px rgba(0, 192, 232, 0.4), 0 0 40px rgba(0, 192, 232, 0.2)',
+        'glow-brand': '0 0 22px rgba(0, 204, 140, 0.35), 0 0 48px rgba(0, 192, 232, 0.25)',
+        'glow-success': '0 0 20px rgba(0, 204, 140, 0.35), 0 0 45px rgba(0, 204, 140, 0.2)',
+        'glow-blue': '0 0 22px rgba(0, 192, 232, 0.35), 0 0 48px rgba(0, 192, 232, 0.2)',
       },
       
       // Modern Animation System  
@@ -212,12 +263,12 @@ module.exports = {
           '70%': { transform: 'translateY(-2px)' },
         },
         glowPulse: {
-          '0%, 100%': { 
-            boxShadow: '0 0 20px rgba(250, 88, 45, 0.4), 0 0 40px rgba(250, 88, 45, 0.1)',
+          '0%, 100%': {
+            boxShadow: '0 0 24px rgba(0, 204, 140, 0.35), 0 0 54px rgba(0, 214, 255, 0.2)',
             transform: 'scale(1)'
           },
-          '50%': { 
-            boxShadow: '0 0 30px rgba(250, 88, 45, 0.6), 0 0 60px rgba(250, 88, 45, 0.2)',
+          '50%': {
+            boxShadow: '0 0 38px rgba(0, 192, 232, 0.35), 0 0 80px rgba(130, 125, 255, 0.25)',
             transform: 'scale(1.02)'
           },
         },
@@ -252,9 +303,9 @@ module.exports = {
       // Brand gradients
       backgroundImage: {
         // Legacy gradients (preserved)
-        'pan-gradient': 'linear-gradient(135deg, #FA582D 0%, #8ad3de 100%)',
-        'pan-gradient-reverse': 'linear-gradient(135deg, #8ad3de 0%, #FA582D 100%)',
-        'cortex-gradient': 'linear-gradient(135deg, #00c0e8 0%, #8ad3de 100%)',
+        'pan-gradient': 'linear-gradient(135deg, rgb(var(--cortex-primary)) 0%, rgb(var(--cortex-blue)) 100%)',
+        'pan-gradient-reverse': 'linear-gradient(135deg, rgb(var(--cortex-blue)) 0%, rgb(var(--cortex-primary)) 100%)',
+        'cortex-gradient': 'linear-gradient(135deg, rgb(var(--cortex-blue)) 0%, rgb(var(--cortex-teal)) 100%)',
         
         // Modern gradients using tokens
         'cortex-brand': 'linear-gradient(135deg, rgb(var(--cortex-primary)) 0%, rgb(var(--cortex-teal)) 100%)',
@@ -303,21 +354,21 @@ module.exports = {
           colorScheme: 'dark',
         },
         'body': {
-          color: '#F5F5F5',
-          backgroundColor: '#000000',
+          color: `rgb(var(--cortex-text-secondary))`,
+          backgroundColor: 'var(--cortex-bg-primary)',
         },
         'h1, h2, h3, h4, h5, h6': {
-          color: '#FFFFFF',
+          color: `rgb(var(--cortex-text-primary))`,
           fontWeight: '600',
         },
         'p, span, div': {
-          color: '#F5F5F5',
+          color: `rgb(var(--cortex-text-secondary))`,
         },
         'input, textarea': {
-          color: '#F5F5F5 !important',
+          color: `rgb(var(--cortex-text-primary)) !important`,
         },
         'input::placeholder, textarea::placeholder': {
-          color: '#999999 !important',
+          color: `rgb(var(--cortex-text-muted)) !important`,
         },
       });
       
@@ -338,24 +389,23 @@ module.exports = {
         },
         
         /* DEPRECATED: Brand aliasing - use cortex.primary instead */
-        '.text-cortex-accent': { color: theme('colors.cortex.primary') },
-        '.bg-cortex-accent': { backgroundColor: theme('colors.cortex.primary') },
-        '.border-cortex-accent': { borderColor: theme('colors.cortex.primary') },
+        '.text-cortex-accent': { color: theme('colors.cortex.accent') },
+        '.bg-cortex-accent': { backgroundColor: theme('colors.cortex.accent') },
+        '.border-cortex-accent': { borderColor: theme('colors.cortex.accent') },
         
         /* DEPRECATED: Status aliasing - use status.* instead */
-        '.text-cortex-success': { color: theme('colors.status.success') },
-        '.bg-cortex-success': { backgroundColor: theme('colors.status.success') },
-        '.text-cortex-warning': { color: theme('colors.status.warning') },
-        '.bg-cortex-warning': { backgroundColor: theme('colors.status.warning') },
-        '.text-cortex-error': { color: theme('colors.status.error') },
-        '.bg-cortex-error': { backgroundColor: theme('colors.status.error') },
-        '.text-cortex-info': { color: theme('colors.cortex.blue') },
-        '.bg-cortex-info': { backgroundColor: theme('colors.cortex.blue') },
+        '.text-status-success': { color: theme('colors.status.success') },
+        '.bg-status-success': { backgroundColor: theme('colors.status.success') },
+        '.text-status-warning': { color: theme('colors.status.warning') },
+        '.bg-status-warning': { backgroundColor: theme('colors.status.warning') },
+        '.text-status-error': { color: theme('colors.status.error') },
+        '.bg-status-error': { backgroundColor: theme('colors.status.error') },
+        '.text-status-info': { color: theme('colors.status.info') },
+        '.bg-status-info': { backgroundColor: theme('colors.status.info') },
         
         /* DEPRECATED: Surface aliasing - use cortex.* instead */
-        '.bg-cortex-bg-hover': { backgroundColor: theme('colors.cortex.elevated') },
-        '.bg-cortex-bg-tertiary': { backgroundColor: theme('colors.cortex.surface') },
-        '.border-cortex-border-secondary': { borderColor: theme('colors.cortex.border') },
+        '.bg-cortex-bg-hover': { backgroundColor: theme('colors.cortex.bg-hover') },
+        '.bg-cortex-bg-tertiary': { backgroundColor: theme('colors.cortex.bg-tertiary') },
         
         /* DEPRECATED: Text aliasing - use cortex.text-* instead */
         '.text-cortex-text-primary': { color: theme('colors.cortex.text-primary') },


### PR DESCRIPTION
## Summary
- refresh the global CSS tokens and Tailwind theme to match the updated Cortex brand palette and gradients
- retheme shared components (ThemeProvider variants, terminal sidebar, accent usage) and documentation to rely on the new tokens

## Testing
- npm run lint *(fails: hosting/lib/dc-api-client.ts duplicate firebase/firestore import and numerous existing warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68e829c2b3e48326b13223e839d8c618