### PR TITLE
feat: persist management dashboard updates and refresh Cortex icons

### DIFF
--- a/hosting/app/layout.tsx
+++ b/hosting/app/layout.tsx
@@ -1,13 +1,27 @@
+import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import './dc-portal-styles.css';
 import { AuthProvider } from '../contexts/AuthContext';
 import { AppStateProvider } from '../contexts/AppStateContext';
 import ConditionalLayout from '../components/ConditionalLayout';
 
-export const metadata = {
+const cortexFaviconSvg = '/assets/branding/favicons/favicon.svg';
+const cortexFaviconIco = '/assets/branding/favicons/favicon.ico';
+const cortexPng32 = '/assets/branding/icons/cortex-32x32.png';
+const cortexPng192 = '/assets/branding/icons/cortex-192x192.png';
+
+export const metadata: Metadata = {
   title: 'Cortex Domain Consultant Platform',
-  description: 'Professional engagement platform for project management, customer demos, and technical solutions',
-  keywords: 'Henry Reed AI, Professional Platform, Project Management, Customer Engagement, Technical Solutions, Portfolio Management',
+  description:
+    'Professional engagement platform for project management, customer demos, and technical solutions',
+  keywords: [
+    'Henry Reed AI',
+    'Professional Platform',
+    'Project Management',
+    'Customer Engagement',
+    'Technical Solutions',
+    'Portfolio Management',
+  ],
   authors: [{ name: 'Henry Reed AI', url: 'https://henryreed.ai' }],
   creator: 'Henry Reed AI',
   publisher: 'Henry Reed AI',
@@ -22,14 +36,15 @@ export const metadata = {
   },
   openGraph: {
     title: 'Cortex Domain Consultant Platform',
-    description: 'Professional platform for project management, customer engagement, and technical solutions',
+    description:
+      'Professional platform for project management, customer engagement, and technical solutions',
     url: 'https://henryreed.ai',
     siteName: 'Henry Reed AI',
     locale: 'en_US',
     type: 'website',
     images: [
       {
-        url: '/assets/branding/icons/cortex-192x192.png',
+        url: cortexPng192,
         width: 192,
         height: 192,
         alt: 'Cortex Domain Consultant Portal',
@@ -39,8 +54,9 @@ export const metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Cortex Domain Consultant Platform',
-    description: 'Professional platform for project management, customer engagement, and technical solutions',
-    images: ['/assets/branding/icons/cortex-192x192.png'],
+    description:
+      'Professional platform for project management, customer engagement, and technical solutions',
+    images: [cortexPng192],
   },
   robots: {
     index: true,
@@ -55,21 +71,19 @@ export const metadata = {
   },
   icons: {
     icon: [
-      // Cortex neural network SVG favicon (primary)
-      { url: '/favicon.svg', type: 'image/svg+xml' },
-      // PNG fallbacks for older browsers
-      { url: '/assets/branding/icons/cortex-32x32.png', sizes: '32x32', type: 'image/png' },
-      { url: '/assets/branding/icons/cortex-192x192.png', sizes: '192x192', type: 'image/png' },
+      { url: cortexFaviconSvg, type: 'image/svg+xml' },
+      { url: cortexFaviconIco, sizes: 'any' },
+      { url: cortexPng32, sizes: '32x32', type: 'image/png' },
+      { url: cortexPng192, sizes: '192x192', type: 'image/png' },
     ],
-    shortcut: '/favicon.svg',
-    apple: [
-      { url: '/assets/branding/icons/cortex-192x192.png', sizes: '180x180', type: 'image/png' },
-    ],
+    shortcut: [cortexFaviconIco],
+    apple: [{ url: cortexPng192, sizes: '180x180', type: 'image/png' }],
+    other: [{ rel: 'mask-icon', url: cortexFaviconSvg, color: '#00CC66' }],
   },
   manifest: '/manifest.json',
 };
 
-export const viewport = {
+export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
@@ -84,9 +98,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-        <link rel="alternate icon" href="/assets/branding/icons/cortex-32x32.png" />
-        <link rel="apple-touch-icon" href="/assets/branding/icons/cortex-192x192.png" />
+        <link rel="icon" href={cortexFaviconSvg} type="image/svg+xml" />
+        <link rel="alternate icon" href={cortexPng32} type="image/png" />
+        <link rel="icon" href={cortexFaviconIco} type="image/x-icon" />
+        <link rel="apple-touch-icon" href={cortexPng192} />
         <link rel="manifest" href="/manifest.json" />
         <meta name="theme-color" content="#00CC66" />
         <meta name="msapplication-TileColor" content="#00CC66" />

--- a/hosting/lib/dc-api-client.ts
+++ b/hosting/lib/dc-api-client.ts
@@ -23,9 +23,9 @@ import {
   query,
   updateDoc,
   where,
-  setDoc
+  setDoc,
+  type QueryConstraint,
 } from 'firebase/firestore';
-import type { QueryConstraint } from 'firebase/firestore';
 
 // API Response Types
 export interface APIResponse<T = any> {


### PR DESCRIPTION
## Summary
- point Next.js metadata and inline head tags at the existing Cortex favicon set for consistent branding
- expose a typed userManagementService.updateUser helper that refreshes local caches after calling the backend
- wire ManagementDashboard role/status handlers through the service, surface mutation feedback with CortexButton actions, and clean up lint duplication in dc-api-client

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e83f740d148326afb71df2d1a933c1