### PR TITLE
Fix TRR navigation and restore auth guard enforcement

### DIFF
--- a/hosting/app/content/page.tsx
+++ b/hosting/app/content/page.tsx
@@ -16,7 +16,7 @@ const EnhancedContentCreator = dynamic(() => import('../../components/EnhancedCo
 });
 
 export default function ContentPage() {
-  const isAuthenticated = useAuthGuard();
+  const { isAuthenticated } = useAuthGuard();
 
   if (isAuthenticated === null) {
     return (

--- a/hosting/app/terminal/page.tsx
+++ b/hosting/app/terminal/page.tsx
@@ -7,7 +7,7 @@ import { useAuthGuard } from '../../hooks/useAuthGuard';
 import { Loading } from '../../components/ui';
 
 export default function TerminalPage() {
-  const isAuthenticated = useAuthGuard();
+  const { isAuthenticated } = useAuthGuard();
 
   if (isAuthenticated === null) {
     return <Loading size="lg" text="Initializing Cortex DC Portal..." fullscreen />;

--- a/hosting/app/trr/TRRClient.tsx
+++ b/hosting/app/trr/TRRClient.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+import { Loading } from '../../components/ui';
+import { useAuthGuard } from '../../hooks/useAuthGuard';
+
+const ProductionTRRManagement = dynamic(
+  () =>
+    import('../../components/ProductionTRRManagement').then(mod => ({
+      default: mod.ProductionTRRManagement,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <Loading size="lg" text="Loading TRR management workspace..." fullscreen />
+    ),
+  },
+);
+
+export function TRRClient() {
+  const { isAuthenticated } = useAuthGuard();
+
+  if (isAuthenticated === null) {
+    return <Loading size="lg" text="Initializing TRR management experience..." fullscreen />;
+  }
+
+  if (isAuthenticated) {
+    return <ProductionTRRManagement />;
+  }
+
+  return null;
+}

--- a/hosting/app/trr/page.tsx
+++ b/hosting/app/trr/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react';
+
+import { Loading } from '../../components/ui';
+
+import { TRRClient } from './TRRClient';
+
+export default function TRRPage() {
+  return (
+    <Suspense
+      fallback={
+        <Loading
+          size="lg"
+          text="Initializing TRR management experience..."
+          fullscreen
+        />
+      }
+    >
+      <TRRClient />
+    </Suspense>
+  );
+}

--- a/hosting/components/AppHeader.tsx
+++ b/hosting/components/AppHeader.tsx
@@ -252,24 +252,24 @@ export default function AppHeader() {
 
             {/* Mobile Navigation - Icon Only */}
             <nav className="flex md:hidden items-center space-x-1">
-              <Link href="/gui" className={`p-2 rounded-lg ${isGUI ? 'bg-cortex-orange text-white' : 'text-cortex-text-secondary hover:bg-cortex-bg-hover'}`}>
+              <Link href="/gui" className={`px-2 py-2 rounded-lg ${isGUI ? 'bg-cortex-orange text-white' : 'text-cortex-text-secondary hover:bg-cortex-bg-hover'}`}>
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2H5a2 2 0 00-2-2z" />
                 </svg>
               </Link>
               {hasTerminalAccess && (
-                <Link href="/terminal" className={`p-2 rounded-lg ${isTerminal ? 'bg-cortex-green text-white' : 'text-cortex-text-secondary hover:bg-cortex-bg-hover'}`}>
+                <Link href="/terminal" className={`px-2 py-2 rounded-lg ${isTerminal ? 'bg-cortex-green text-white' : 'text-cortex-text-secondary hover:bg-cortex-bg-hover'}`}>
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                   </svg>
                 </Link>
               )}
-              <Link href="/trr" className={`p-2 rounded-lg ${isTRR ? 'bg-cortex-orange text-white' : 'text-cortex-text-secondary hover:bg-cortex-bg-hover'}`}>
+              <Link href="/trr" className={`px-2 py-2 rounded-lg ${isTRR ? 'bg-cortex-orange text-white' : 'text-cortex-text-secondary hover:bg-cortex-bg-hover'}`}>
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                 </svg>
               </Link>
-              <Link href="/content" className={`p-2 rounded-lg ${isContent ? 'bg-cortex-green text-white' : 'text-cortex-text-secondary hover:bg-cortex-bg-hover'}`}>
+              <Link href="/content" className={`px-2 py-2 rounded-lg ${isContent ? 'bg-cortex-green text-white' : 'text-cortex-text-secondary hover:bg-cortex-bg-hover'}`}>
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                 </svg>


### PR DESCRIPTION
## Summary
- add a dedicated `/trr` page that loads the production Technical Requirements Review workspace
- fix the content and terminal routes to correctly consume the auth guard return value so unauthenticated users are redirected
- split the `/trr` route into a server wrapper and client entry point so the auth guard stays client-side while the page renders with a suspense fallback
- align the mobile header navigation buttons (including Terminal) to use consistent `px-2 py-2` padding

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e8474ae4208326b63b9d7240394498